### PR TITLE
Input variables on all keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,9 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install test dependencies
+      - name: Install pip dependencies
         run: |
-          pip install pydantic==2.*
-          pip install coverage==7.0.1
+          pip install pydantic==2.* Jinja2==3.* coverage==7.0.1
 
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ![CI](https://github.com/wolflu05/inventree-bulk-plugin/actions/workflows/ci.yml/badge.svg)
 
-> :warning: This plugin is currently in beta because it needs to be properly tested to be used in production.
+> [!WARNING]
+> This plugin is currently in beta because it needs to be properly tested to be used in production.
 
 A bulk creation plugin for [InvenTree](https://inventree.org), which helps you generating locations/categories in bulk by using customized naming strategies and ensure them along your complete storage tree.
 
@@ -35,22 +36,29 @@ You can save bulk creation templates to ensure consistency along your storage tr
 4. Create you template by using "Create"
 5. Goto the specific sub-location where you want to apply that template, load it and Bulk generate your locations to your needs.
 
-> :information_source: You can use inputs to make your bulk creation schema dynamic in amount of drawers or their names.
+> [!NOTE]
+> You can use [inputs](#input) to make your bulk creation schema dynamic in amount of drawers or their names.
 
 ### Bulk creation editor
 
+The bulk creation editor helps you to define the generation schema. 
+
+> [!NOTE]
+> You can use [Jinja2 templating](https://jinja.palletsprojects.com/en/3.1.x/templates/) in every field (except in the `input` section). You can also use filters to manipulate the dimension output.
+> **Global context:**
+> - `inp.<key>` - Access [input variables](#input), e.g. (`{{inp.drawer_count|int / 2}}`)
+
 #### Input
 
-You can define key/value pairs of inputs which you can later reference in your schema via `{inp.<key>}`. This is useful for [saved templates](#saved-templates).
-
-> :warning: This is currently not fully working - see [#10](https://github.com/wolflu05/inventree-bulk-plugin/issues/10)
+You can define key/value pairs of inputs which you can later reference in your schema via `{{inp.<key>}}`. This is useful for [saved templates](#saved-templates) to dynamically generate the amount of locations as you want, but still keep the structure.
 
 #### Settings
 
 - `Count from` - defines from where to start with counting numbers in dimensions.
 - `Leading zeros` - defines if it needs to add leading zeros to numbers to ensure consistent length.
 
-> :warning: These settings are currently not working - see [#18](https://github.com/wolflu05/inventree-bulk-plugin/issues/18)
+> [!NOTE]
+> :construction: These settings are currently not working - see [#18](https://github.com/wolflu05/inventree-bulk-plugin/issues/18)
 
 #### Templates
 
@@ -71,7 +79,7 @@ Select a template to extend from
 ##### Dimensions/Count
 Dimensions are a way to add various counting strategies to your naming. You can add a dimension by clicking on "Add dimension" and remove it via the red "X" on the right of the dimension field.
 
-A `dimension` can contain comma separated generators which generate the values for you. There are three types of generators. You can use the `count` field to limit a dimension to a specific amount of generating items. These generators can have arguments parsed via the following syntax: `GENERATOR{key1=value,key2=value}`, where `GENERATOR` is the name/range. <br/>
+A `dimension` can contain comma separated generators which generate the values for you. There are three types of generators. You can use the `count` field to limit a dimension to a specific amount of generating items. These generators can have arguments parsed via the following syntax: `GENERATOR(key1=value,key2=value)`, where `GENERATOR` is the name/range. <br/>
 
 **Generator types:**<br/>
 Word: _any arbitrary word, not starting with `*`_. E.g. `hello world`<br/>
@@ -79,18 +87,21 @@ Ranges: _ranges are defined with a - in the middle_ E.g. `a-bx`<br/>
 Infinity: _infinity generators start with a *_ E.g. `*NUMERIC`<br/>
 
 **Available Generators:**<br/>
-Numeric generator: `*NUMERIC{start=0,end=10,step=2,count=5}` or `0-10{step=2}`<br/>
-Alpha generator: `*ALPHA{casing=upper|lower,start=A,end=F,step=2,count=3}` or `a-z{step=2}`<br/><br />
+Numeric generator: `*NUMERIC(start=0,end=10,step=2,count=5}` or `0-10(step=2}`<br/>
+Alpha generator: `*ALPHA(casing=upper|lower,start=A,end=F,step=2,count=3)` or `a-z(step=2)`<br/><br />
 
-Example: `1-3,hello,*NUMERIC{start=1,step=2,end=10},*ALPHA{casing=upper,end=B},A-D{step=2}`, this will generate the following dimension: `12,3,hello,1,3,5,7,9,A,B,A,C`.
+Example: `1-3,hello,*NUMERIC(start=1,step=2,end=10),*ALPHA(casing=upper,end=B),A-D(step=2)`, this will generate the following dimension: `12,3,hello,1,3,5,7,9,A,B,A,C`.
 
-> :warning: Infinity generators need a `count` argument or a global count limitation, otherwise generation will fail.
+> [!IMPORTANT]
+> Infinity generators need a `count` argument or a global count limitation, otherwise generation will fail.
 
 ##### Generate
 
 These fields my differ between stock location and part category. They correspond to the generated items property. For example "Generate Name" will be the name of the created location/category. 
 
-> :information_source: You can use `{dim.<x>}` as a placeholder for the generated output of the dimension and `{inp.<key>}` for replacing with the given input value. Dimension numbering is starting with 1, so you can reference the value of the first dimension via `{dim.1}`.
+> [!NOTE]
+> **Extended Jinja2 context**:
+> - `dim.<x>` - reference the n-th dimension, one-based (e.g. `{{dim.1}}` to access the first dimension)
 
 ##### Child's
 
@@ -100,7 +111,7 @@ Child's are a way to add some nesting to your bulk creation tree. You can use th
 
 #### Why does this plugin needs the App Mixin?
 
-> This plugin uses the App Mixin to add a custom model to the database to manage stored templates which ensure consistency along your creation of storage trees. (See [Saved templates](#saved-templates))
+> This plugin uses the App Mixin to add a custom model to the database to manage stored templates which ensure consistency along your creation of storage trees. (See [Saved templates](#saved-templates)). Additionally the App Mixin is used to provide the static files that are required for the reactive interface powered by preact.
 
 #### Why does this plugin needs the Url Mixin?
 

--- a/inventree_bulk_plugin/BulkGenerator/BulkGenerator.py
+++ b/inventree_bulk_plugin/BulkGenerator/BulkGenerator.py
@@ -139,7 +139,8 @@ class BulkGenerator:
         for key, template_str in child.generate.items():
             try:
                 compiled_templates[key] = Template(template_str).compile()
-            except TemplateError as e:
+            except TemplateError as e:  # pragma: no cover
+                # catch this error in any case it bypasses validation somehow because an error is not handled during ast creation but occurred on compile
                 raise ValueError(f"Invalid generator template '{template_str}'\nException: {e}")
 
         def render(**ctx):

--- a/inventree_bulk_plugin/BulkGenerator/dimensions.py
+++ b/inventree_bulk_plugin/BulkGenerator/dimensions.py
@@ -8,7 +8,7 @@ from .generators.generator import Generator, GeneratorTypes
 
 def parse_dimension(dimension: str) -> list[tuple[GeneratorTypes, Union[str, tuple[str, str]], dict, str]]:
     res = []
-    for gen_match in re.finditer(r"(?:(?:(\w+)-(\w+))|(\*?\w+))(?:{(.*?)})?(?:,|$)", dimension):
+    for gen_match in re.finditer(r"(?:(?:(\w+)-(\w+))|(\*?\w+))(?:\((.*?)\))?(?:,|$)", dimension):
         settings = {}
         if gen_match.group(4):
             for setting_match in re.finditer(r"([A-Za-z_]+?)(?:=)([^=]+)(?:,|$)", gen_match.group(4)):

--- a/inventree_bulk_plugin/BulkGenerator/template.py
+++ b/inventree_bulk_plugin/BulkGenerator/template.py
@@ -1,0 +1,15 @@
+from jinja2 import Environment
+
+env = Environment(variable_start_string="${{", variable_end_string="}}")
+
+
+class Template:
+    def __init__(self, template_str: str) -> None:
+        self.template_str = template_str
+
+    def validate(self):
+        env.parse(self.template_str)
+        return True
+
+    def compile(self):
+        return env.from_string(self.template_str)

--- a/inventree_bulk_plugin/BulkGenerator/template.py
+++ b/inventree_bulk_plugin/BulkGenerator/template.py
@@ -1,6 +1,6 @@
 from jinja2 import Environment
 
-env = Environment(variable_start_string="${{", variable_end_string="}}")
+env = Environment(variable_start_string="{{", variable_end_string="}}")
 
 
 class Template:

--- a/inventree_bulk_plugin/BulkGenerator/validations.py
+++ b/inventree_bulk_plugin/BulkGenerator/validations.py
@@ -45,10 +45,6 @@ class BulkDefinitionSchema(BaseModel):
     @field_validator("settings", "templates", "output", mode="before", check_fields=True)
     @classmethod
     def apply_input_hook(cls, value, field_info: FieldValidationInfo):
-        return cls.apply_input_to_field(value, field_info)
-
-    @classmethod
-    def apply_input_to_field(cls, value, field_info: FieldValidationInfo):
         errors = list[str]()
 
         def _apply_input(value, path: str):

--- a/inventree_bulk_plugin/BulkGenerator/validations.py
+++ b/inventree_bulk_plugin/BulkGenerator/validations.py
@@ -1,5 +1,10 @@
+import re
 from typing import List, Optional, Dict, Union, Tuple
-from pydantic import BaseModel, PrivateAttr
+from pydantic import BaseModel, FieldValidationInfo, PrivateAttr, field_validator
+from pydantic_core import PydanticCustomError
+from jinja2.exceptions import TemplateError
+
+from .template import Template
 
 
 BulkDefinitionChildDimensions = Optional[List[str]]
@@ -29,8 +34,48 @@ class BulkDefinitionSettings(BaseModel):
 
 
 class BulkDefinitionSchema(BaseModel):
+    apply_input: bool = False  # is not part of the definition schema, but used to determine if the input should be applied
+
     version: str
     input: Dict[str, str]
     settings: Optional[BulkDefinitionSettings] = BulkDefinitionSettings()
     templates: List["BulkDefinitionChildTemplate"]
     output: "BulkDefinitionChild"
+
+    @field_validator("settings", "templates", "output", mode="before", check_fields=True)
+    @classmethod
+    def apply_input(cls, value, field_info: FieldValidationInfo):
+        errors = list[str]()
+
+        def _apply_input(value, path: str):
+            if isinstance(value, dict):
+                for k, v in value.items():
+                    value[k] = _apply_input(v, f"{path}.{k}")
+            elif isinstance(value, list):
+                for i, v in enumerate(value):
+                    value[i] = _apply_input(v, f"{path}.{i}")
+            elif isinstance(value, str):
+                use_extra_contexts = [r".*\.generate\.\w+$"]
+
+                try:
+                    # if path ends with one in use_extra_contexts, only validate the template,
+                    # because the full variable context is not available to this time
+                    if any(re.match(pattern, path) for pattern in use_extra_contexts):
+                        Template(value).validate()
+                    else:
+                        template = Template(value).compile()
+                        rendered_value = template.render(inp=field_info.data["input"])
+                        if field_info.data["apply_input"]:
+                            value = rendered_value
+                except TemplateError as e:
+                    errors.append(f'{path}: {e} (template="{value}")')
+
+            return value
+
+        # recursively walk through the provided data structure and validate/apply template
+        _apply_input(value, field_info.field_name)
+
+        if len(errors) > 0:
+            raise PydanticCustomError("template_error", "\n".join(errors))
+
+        return value

--- a/inventree_bulk_plugin/BulkGenerator/validations.py
+++ b/inventree_bulk_plugin/BulkGenerator/validations.py
@@ -44,7 +44,11 @@ class BulkDefinitionSchema(BaseModel):
 
     @field_validator("settings", "templates", "output", mode="before", check_fields=True)
     @classmethod
-    def apply_input(cls, value, field_info: FieldValidationInfo):
+    def apply_input_hook(cls, value, field_info: FieldValidationInfo):
+        return cls.apply_input_to_field(value, field_info)
+
+    @classmethod
+    def apply_input_to_field(cls, value, field_info: FieldValidationInfo):
         errors = list[str]()
 
         def _apply_input(value, path: str):

--- a/inventree_bulk_plugin/templates/components/BulkDefinitionSchemaBuilder.js
+++ b/inventree_bulk_plugin/templates/components/BulkDefinitionSchemaBuilder.js
@@ -63,8 +63,16 @@ function BulkDefinitionSchemaBuilder({ schema, setSchema, generateKeys = {} }) {
   , [setInput]);
   // hook input array state up to schema.input as an object
   useEffect(() => {
-    setSchema(s => ({...s, input: Object.fromEntries(input.map(({key, value}) => [key,value]))}))
-  }, [input, setSchema])
+    if (input.length > 0) {
+      setSchema(s => ({...s, input: Object.fromEntries(input.map(({key, value}) => [key,value]))}))
+    }
+  }, [input, setSchema]);
+  // load input on initial load
+  useEffect(() => {
+    if(input.length === 0 && schema?.input && Object.keys(schema.input).length !== 0) {
+      setInput(Object.entries(schema.input).map(([key, value]) => ({ key, value })));
+    }
+  }, [schema?.input, input, setInput]);
 
   // template
   const setTemplate = useCallback((i) => (newTemplate) => setSchema(s => {

--- a/inventree_bulk_plugin/templates/panels/stock-index/manage-bulk.js
+++ b/inventree_bulk_plugin/templates/panels/stock-index/manage-bulk.js
@@ -54,7 +54,7 @@ function EditForm({ template, setTemplate, templateTypeOptions = {}, handleBack 
       const create = template.id === null;
       const res = await fetch("{% url 'plugin:inventree-bulk-plugin:templates' %}" + `/${create ? "" : template.id }`, {
         method: create ? "POST" : "PUT",
-        body: JSON.stringify({...template, template: JSON.stringify(template.template)})
+        body: JSON.stringify({...template, template: JSON.stringify(beautifySchema(template.template))})
       });
       const data = await res.json();
 

--- a/inventree_bulk_plugin/tests/integration/test_InvenTreeBulkPlugin.py
+++ b/inventree_bulk_plugin/tests/integration/test_InvenTreeBulkPlugin.py
@@ -73,16 +73,16 @@ class InvenTreeBulkPluginAPITestCase(InvenTreeAPITestCase):
                 "dimensions": ["*NUMERIC"],
                 "count": [5],
                 "generate": {
-                    "name": "N{dim.1}",
-                            "description": "D{dim.1}"
+                    "name": "N{{dim.1}}",
+                            "description": "D{{dim.1}}"
                 },
                 "childs": [
                     {
-                        "dimensions": ["*ALPHA{casing=lower}"],
+                        "dimensions": ["*ALPHA(casing=lower)"],
                         "count": [2],
                         "generate": {
-                            "name": "CN{dim.1}",
-                                    "description": "CD{dim.1}"
+                            "name": "CN{{dim.1}}",
+                                    "description": "CD{{dim.1}}"
                         },
                         "childs": [
                             {"generate": {"name": "Name", "description": "Description"}}
@@ -135,7 +135,7 @@ class InvenTreeBulkPluginAPITestCase(InvenTreeAPITestCase):
             "templates": [],
             "output": {
                 "generate": {
-                    "name": "{not.existing.context}",
+                    "name": "{{not.existing.context}}",
                 },
             }
         }

--- a/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
+++ b/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
@@ -8,8 +8,8 @@ class BulkGeneratorTestCase(unittest.TestCase):
     def test_1D_generation(self):
         dimensions = [
             ("*NUMERIC", list(range(1, 6))),
-            ("*ALPHA{casing=upper}", ["A", "B", "C", "D", "E"]),
-            ("*ALPHA{casing=lower}", ["a", "b", "c", "d", "e"]),
+            ("*ALPHA(casing=upper)", ["A", "B", "C", "D", "E"]),
+            ("*ALPHA(casing=lower)", ["a", "b", "c", "d", "e"]),
         ]
 
         for dim, exp in dimensions:
@@ -22,7 +22,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                         "dimensions": [dim],
                         "count": ["5"],
                         "generate": {
-                            "name": "before{dim.1}after",
+                            "name": "before{{dim.1}}after",
                         },
                         "childs": []
                     }
@@ -42,9 +42,9 @@ class BulkGeneratorTestCase(unittest.TestCase):
                     "dimensions": ["*NUMERIC"],
                     "count": ["4"],
                     "generate": {
-                        "name": "{dim.1} from template",
+                        "name": "{{dim.1}} from template",
                         "description": "",
-                        "abc": "{dim.1} from template"
+                        "abc": "{{dim.1}} from template"
                     },
                     "childs": []
                 }
@@ -54,8 +54,8 @@ class BulkGeneratorTestCase(unittest.TestCase):
                 "dimensions": [""],
                 "count": ["10"],
                 "generate": {
-                    "name": "{dim.1} from child",
-                    "description": "{dim.1} from child",
+                    "name": "{{dim.1}} from child",
+                    "description": "{{dim.1}} from child",
                     "abc": ""
                 },
                 "childs": []
@@ -134,7 +134,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
         self.assertEqual(0, len(res[0][1]))
 
     def test_invalid_template(self):
-        with self.assertRaisesRegex(ValueError, "Invalid generator template '{hello.world}'\nException: .*"):
+        with self.assertRaisesRegex(ValueError, "Exception: 'hello' is undefined"):
             BulkGenerator({
                 "version": "0.1.0",
                 "input": {},
@@ -143,7 +143,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                     "dimensions": [],
                     "count": [],
                     "generate": {
-                        "name": "{hello.world}",
+                        "name": "{{hello.world}}",
                     },
                     "childs": []
                 }
@@ -199,7 +199,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
             "output": {
                 "dimensions": ["*NUMERIC"],
                 "count": [9],
-                "generate": {"name": "{dim.1}"},
+                "generate": {"name": "{{dim.1}}"},
                 "childs": [
                     {
                         "parent_name_match": "[0-4]",
@@ -226,7 +226,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                 "output": {
                     "dimensions": ["*NUMERIC"],
                     "count": [9],
-                    "generate": {"name": "{dim.1}"},
+                    "generate": {"name": "{{dim.1}}"},
                     "childs": [
                         {
                             "parent_name_match": "this pattern wont match",

--- a/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
+++ b/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
@@ -1,8 +1,7 @@
 import unittest
-from unittest import mock
 
 from ...BulkGenerator.BulkGenerator import BulkGenerator, apply_template
-from ...BulkGenerator.validations import BulkDefinitionChild, BulkDefinitionChildTemplate, BulkDefinitionSchema
+from ...BulkGenerator.validations import BulkDefinitionChild, BulkDefinitionChildTemplate
 
 
 class BulkGeneratorTestCase(unittest.TestCase):
@@ -171,8 +170,6 @@ class BulkGeneratorTestCase(unittest.TestCase):
                 }
             }).generate()
 
-    # remove validator for early template validation to catch other errors on runtime
-    @mock.patch.object(BulkDefinitionSchema, "apply_input_to_field", lambda value, field_info: value)
     def test_invalid_template_on_dimensions_render(self):
         cases = [
             ("Invalid template", "{{}", ValueError, r".*"),

--- a/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
+++ b/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
@@ -172,7 +172,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
             }).generate()
 
     # remove validator for early template validation to catch other errors on runtime
-    @mock.patch.object(BulkDefinitionSchema.__pydantic_decorators__, "field_validators", {})
+    @mock.patch.object(BulkDefinitionSchema, "apply_input_to_field", lambda value, field_info: value)
     def test_invalid_template_on_dimensions_render(self):
         cases = [
             ("Invalid template", "{{}", ValueError, r".*"),

--- a/inventree_bulk_plugin/tests/unit/test_dimensions.py
+++ b/inventree_bulk_plugin/tests/unit/test_dimensions.py
@@ -8,18 +8,18 @@ class DimensionsTestCase(unittest.TestCase):
     def test_parse_dimension(self):
         cases = [
             ("hello", [(GeneratorTypes.WORD, "hello", {}, "hello")]),
-            ("hello{hello=world}", [(GeneratorTypes.WORD, "hello", {"hello": "world"}, "hello{hello=world}")]),
+            ("hello(hello=world)", [(GeneratorTypes.WORD, "hello", {"hello": "world"}, "hello(hello=world)")]),
             ("*TEST", [(GeneratorTypes.INFINITY, "TEST", {}, "*TEST")]),
-            ("*TEST{hello=world}", [(GeneratorTypes.INFINITY, "TEST", {"hello": "world"}, "*TEST{hello=world}")]),
+            ("*TEST(hello=world)", [(GeneratorTypes.INFINITY, "TEST", {"hello": "world"}, "*TEST(hello=world)")]),
             ("1-3", [(GeneratorTypes.RANGE, ("1", "3"), {}, "1-3")]),
-            ("12-3435{hello=world}", [(GeneratorTypes.RANGE,
-             ("12", "3435"), {"hello": "world"}, "12-3435{hello=world}")]),
+            ("12-3435(hello=world)", [(GeneratorTypes.RANGE,
+             ("12", "3435"), {"hello": "world"}, "12-3435(hello=world)")]),
             ("A-B", [(GeneratorTypes.RANGE, ("A", "B"), {}, "A-B")]),
             ("ax-za", [(GeneratorTypes.RANGE, ("ax", "za"), {}, "ax-za")]),
-            ("Hello,*abc{a=1,b=(2,3)},1-3{a=1}", [
+            ("Hello,*abc(a=1,b='(2,3)',c=4),1-3(a=1)", [
                 (GeneratorTypes.WORD, "Hello", {}, "Hello"),
-                (GeneratorTypes.INFINITY, "abc", {"a": "1", "b": "(2,3)"}, "*abc{a=1,b=(2,3)}"),
-                (GeneratorTypes.RANGE, ("1", "3"), {"a": "1"}, "1-3{a=1}")
+                (GeneratorTypes.INFINITY, "abc", {"a": "1", "b": "'(2,3)'", "c": "4"}, "*abc(a=1,b='(2,3)',c=4)"),
+                (GeneratorTypes.RANGE, ("1", "3"), {"a": "1"}, "1-3(a=1)")
             ]),
         ]
 
@@ -64,12 +64,12 @@ class DimensionsTestCase(unittest.TestCase):
     def test_get_dimension_values(self):
         cases = [
             ("abc", None, {}, ["abc"]),
-            ("*NUMERIC{start=10, end=14}", None, {}, ["10", "11", "12", "13", "14"]),
-            ("*NUMERIC{start=10, end=14, count=2}", None, {}, ["10", "11"]),
+            ("*NUMERIC(start=10, end=14)", None, {}, ["10", "11", "12", "13", "14"]),
+            ("*NUMERIC(start=10, end=14, count=2)", None, {}, ["10", "11"]),
             ("42-45", None, {}, ["42", "43", "44", "45"]),
-            ("*NUMERIC{start=42,end=45,step=3}", None, {}, ["42", "45"]),
-            ("42-45{step=3}", None, {}, ["42", "45"]),
-            ("*NUMERIC{start=10,count=2}", None, {}, ["10", "11"]),
+            ("*NUMERIC(start=42,end=45,step=3)", None, {}, ["42", "45"]),
+            ("42-45(step=3)", None, {}, ["42", "45"]),
+            ("*NUMERIC(start=10,count=2)", None, {}, ["10", "11"]),
             ("0-2,hello,world", 4, {}, ["0", "1", "2", "hello"]),
         ]
 

--- a/inventree_bulk_plugin/tests/unit/test_generators.py
+++ b/inventree_bulk_plugin/tests/unit/test_generators.py
@@ -9,9 +9,9 @@ from ...BulkGenerator.dimensions import get_dimension_values
 
 class NumericGeneratorTestCase(unittest.TestCase):
     def test_integration(self):
-        self.assertListEqual(list(map(str, range(42, 47, 2))), get_dimension_values("42-46{step=2}", None, {}))
+        self.assertListEqual(list(map(str, range(42, 47, 2))), get_dimension_values("42-46(step=2)", None, {}))
         self.assertListEqual(list(map(str, range(2, 11, 2))), get_dimension_values(
-            "*NUMERIC{start=2,end=10,step=2}", None, {}))
+            "*NUMERIC(start=2,end=10,step=2)", None, {}))
 
     def test_is_generator(self):
         self.assertFalse(NumericGenerator.is_generator("A", "B"))
@@ -29,10 +29,10 @@ class NumericGeneratorTestCase(unittest.TestCase):
 
 class AlphaGeneratorTestCase(unittest.TestCase):
     def test_integration(self):
-        self.assertListEqual(["B", "D", "F"], get_dimension_values("B-F{step=2}", None, {}))
-        self.assertListEqual(["b", "d", "f"], get_dimension_values("*ALPHA{start=B,end=F,step=2}", None, {}))
+        self.assertListEqual(["B", "D", "F"], get_dimension_values("B-F(step=2)", None, {}))
+        self.assertListEqual(["b", "d", "f"], get_dimension_values("*ALPHA(start=B,end=F,step=2)", None, {}))
         self.assertListEqual(["C", "E", "G", "I"], get_dimension_values(
-            "*ALPHA{casing=upper,start=C,end=I,step=2}", None, {}))
+            "*ALPHA(casing=upper,start=C,end=I,step=2)", None, {}))
 
     def test_is_generator(self):
         self.assertFalse(AlphaGenerator.is_generator("1", "2"))

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setuptools.setup(
     packages=setuptools.find_packages(),
 
     install_requires=[
-        "pydantic==2.*"
+        "pydantic==2.*",
+        "Jinja2==3.*",
     ],
 
     setup_requires=[
@@ -40,7 +41,7 @@ setuptools.setup(
         "twine",
     ],
 
-    python_requires=">=3.6",
+    python_requires=">=3.9",
 
     entry_points={
         "inventree_plugins": [


### PR DESCRIPTION
This PR allows the usage of input variables on all fields. It also refactored the template syntax to use `jinja2` templates which offer way more functionality than pythons `.format(...)` function.

## ⚠️ Breaking

This PR changes the bulk creation syntax in a breaking way. 
1. Arguments for generators are now wrapped in round brackets, `*NUMERIC{count=1}` ==> `*NUMERIC(count=1)`
2. Accessing variables now need double curly brackets instead of single one, `{dim.1}` ==> `{{dim.1}}` 
   (This change is due to the integration if the [Jinja2 templating](https://jinja.palletsprojects.com/en/3.1.x/templates/) engine)

---

## Todo
- [x] adjust documentation and add link to [Jinja2 template designer docs](https://jinja.palletsprojects.com/en/3.1.x/templates/)
- [x] add tests
- [x] input doesn't get loaded into SchemaBuilder
- [x] add jinja2 to dependencies
- [x] rethink templating syntax and maybe adjust generator arguments

fixes #10 