### PR TITLE
Added parent context variable to generate context

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,11 @@ These fields my differ between stock location and part category. They correspond
 
 > [!NOTE]
 > **Extended Jinja2 context**:
-> - `dim.<x>` - reference the n-th dimension, one-based (e.g. `{{dim.1}}` to access the first dimension)
+> - `dim.<x>` - n-th dimension, one-based (e.g. `{{dim.1}}` to access the first dimension)
+> - `par.<...>` - parent's context
+> - `par.dim.<x>` - parents's dimensions
+> - `par.gen.<name>` - parent's generated fields (e.g. to reuse the parents name `{{par.gen.name}}`)  
+> - `par.par.<...>` - parent's parent context, can be nested deeply
 
 ##### Child's
 

--- a/inventree_bulk_plugin/BulkGenerator/BulkGenerator.py
+++ b/inventree_bulk_plugin/BulkGenerator/BulkGenerator.py
@@ -82,7 +82,6 @@ class BulkGenerator:
             child = apply_template(child, template)
 
         # generate
-        ctx = {'inp': self.schema.input, 'par': parent_ctx}
         render = self.compile_child_templates(child)
         product = []
         if len(child.dimensions) > 0:
@@ -91,12 +90,10 @@ class BulkGenerator:
             # no dimensions
             product = [{}]
 
+        ctx = {'inp': self.schema.input, 'par': parent_ctx}
         for p in product:
             dim = {(i + 1): x for i, x in enumerate(p)}
-            product_ctx = {
-                **ctx,
-                'dim': dim
-            }
+            product_ctx = {**ctx, 'dim': dim}
             generate_values = render(**product_ctx)
             res.append((generate_values, []))
             child_ctx.append({'dim': dim, 'par': parent_ctx, 'gen': generate_values})

--- a/inventree_bulk_plugin/tests/integration/test_InvenTreeBulkPlugin.py
+++ b/inventree_bulk_plugin/tests/integration/test_InvenTreeBulkPlugin.py
@@ -151,9 +151,6 @@ class InvenTreeBulkPluginAPITestCase(InvenTreeAPITestCase):
                 def url(pk):
                     return reverse(f"plugin:inventree-bulk-plugin:bulkcreate{object_type_name}", kwargs={"pk": pk})
 
-                # wrong schema should produce an error
-                self.post(url(0), {"no valid data": "should produce error"}, expected_code=400)
-
                 # no existing parent
                 all_objects = list(object_class.objects.all())
                 self.assertEqual(0, len(all_objects))
@@ -165,6 +162,9 @@ class InvenTreeBulkPluginAPITestCase(InvenTreeAPITestCase):
 
                 all_objects = list(object_class.objects.all())
                 self.assertEqual(26, len(all_objects))
+
+                # wrong schema, existing parent should produce an error
+                self.post(url(0), {"no valid data": "should produce error"}, expected_code=400)
 
     def test__bulk_create(self):
         items = BulkGenerator(self.complex_valid_generation_template).generate()

--- a/inventree_bulk_plugin/tests/integration/test_InvenTreeBulkPlugin.py
+++ b/inventree_bulk_plugin/tests/integration/test_InvenTreeBulkPlugin.py
@@ -163,8 +163,8 @@ class InvenTreeBulkPluginAPITestCase(InvenTreeAPITestCase):
                 all_objects = list(object_class.objects.all())
                 self.assertEqual(26, len(all_objects))
 
-                # wrong schema, existing parent should produce an error
-                self.post(url(0), {"no valid data": "should produce error"}, expected_code=400)
+                # existing parent, wrong schema should produce an error
+                self.post(url(parent.pk), {"no valid data": "should produce error"}, expected_code=400)
 
     def test__bulk_create(self):
         items = BulkGenerator(self.complex_valid_generation_template).generate()

--- a/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
+++ b/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
@@ -279,3 +279,23 @@ class BulkGeneratorTestCase(unittest.TestCase):
                     ]
                 }
             }).generate()
+
+    def test_parent_context(self):
+        res = BulkGenerator({
+            "version": "0.1.0",
+            "input": {},
+            "templates": [],
+            "output": {
+                "dimensions": ["A-B"],
+                "generate": {"name": "First {{dim.1}}"},
+                "child": {
+                    "generate": {"name": "Second {{dim.1}}"},
+                    "child": {
+                        "generate": {"parent_name": "{{par.gen.name}}", "parent_parent_dim_1": "{{par.par.dim.1}}"}
+                    }
+                }
+            }
+        }).generate()
+
+        self.assertListEqual([({'name': 'First A'}, [({'name': 'Second '}, [({'parent_name': 'Second ', 'parent_parent_dim_1': 'A'}, [])])]), ({
+                             'name': 'First B'}, [({'name': 'Second '}, [({'parent_name': 'Second ', 'parent_parent_dim_1': 'B'}, [])])])], res)


### PR DESCRIPTION
This PR adds the new `par` variable to the generate context to access the parents context including `dim`, `gen` and `par` (the parents parent).

resolves #5 