### PR TITLE
Child len context

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ These fields my differ between stock location and part category. They correspond
 
 > [!NOTE]
 > **Extended Jinja2 context**:
-> - `dim.<x>` - n-th dimension, one-based (e.g. `{{dim.1}}` to access the first dimension)
+> - `len` - count of elements this child will generate
+> - `dim.<x>` - x-th dimension, one-based (e.g. `{{dim.1}}` to access the first dimension)
+> - `dim.<x>.len` - count of items the x-th dimension has
 > - `par.<...>` - parent's context
 > - `par.dim.<x>` - parents's dimensions
 > - `par.gen.<name>` - parent's generated fields (e.g. to reuse the parents name `{{par.gen.name}}`)  

--- a/inventree_bulk_plugin/BulkGenerator/BulkGenerator.py
+++ b/inventree_bulk_plugin/BulkGenerator/BulkGenerator.py
@@ -1,6 +1,6 @@
 import itertools
 import re
-from typing import Any
+from typing import Any, Iterable
 
 from jinja2.exceptions import TemplateError
 
@@ -47,6 +47,15 @@ def apply_template(obj: BulkDefinitionChild, template: BulkDefinitionChildTempla
     return obj
 
 
+class DimStr(str):
+    """String that also has a len attribute."""
+    def __new__(cls, value, *args, **kwargs) -> None:
+        return super(DimStr, cls).__new__(cls, value)
+
+    def __init__(self, value, length):
+        self.len = length
+
+
 class BulkGenerator:
     def __init__(self, inp):
         self.inp = inp
@@ -87,16 +96,21 @@ class BulkGenerator:
         # generate
         render = self.compile_child_templates(child)
         product = []
+        dimensions = []
         if len(child.dimensions) > 0:
-            product = list(self.generate_product(child.dimensions, child.count, child))
+            dimensions = self.get_dimensions(child.dimensions, child.count)
+            product = list(itertools.product(*dimensions, repeat=1))
         else:
             # no dimensions
-            product = [{}]
+            product = [()]
+
+        # get length from dimensions
+        dimensions = list(map(len, dimensions))
 
         default_context = self.get_default_context()
         ctx = {'par': parent_ctx, 'len': len(product)}
         for p in product:
-            dim = {(i + 1): x for i, x in enumerate(p)}
+            dim = {(i + 1): DimStr(x, dimensions[i]) for i, x in enumerate(p)}
             product_ctx = {**default_context, **ctx, 'dim': dim}
             generate_values = render(**product_ctx)
             res.append((generate_values, []))
@@ -135,12 +149,12 @@ class BulkGenerator:
 
         return res
 
-    def generate_product(self, dimensions: BulkDefinitionChildDimensions, count: BulkDefinitionChildCount, child: BulkDefinitionChild):
+    def get_dimensions(self, dimensions: BulkDefinitionChildDimensions, count: BulkDefinitionChildCount) -> list[Iterable[str]]:
         seq = []
         for d, c in itertools.zip_longest(dimensions, count, fillvalue=None):
             seq.append(get_dimension_values(d, c))
 
-        return itertools.product(*seq, repeat=1)
+        return seq
 
     def compile_child_templates(self, child: BulkDefinitionChild):
         compiled_templates = {}

--- a/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
+++ b/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
@@ -306,12 +306,14 @@ class BulkGeneratorTestCase(unittest.TestCase):
             "input": {},
             "templates": [],
             "output": {
-                "dimensions": ["*NUMERIC"],
-                "count": [8],
-                "generate": {"length": "{{len}}"},
+                "dimensions": ["*NUMERIC", "*ALPHA"],
+                "count": [10, 2],
+                "generate": {"length": "{{len}}", "dim1len": "{{dim.1.len}}", "dim2len": "{{dim.2.len}}"},
             }
         }).generate()
 
-        self.assertEqual(8, len(res))
+        self.assertEqual(20, len(res))
         for e, _ in res:
-            self.assertEqual("8", e['length'])
+            self.assertEqual("20", e['length'])
+            self.assertEqual("10", e['dim1len'])
+            self.assertEqual("2", e['dim2len'])

--- a/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
+++ b/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
@@ -299,3 +299,19 @@ class BulkGeneratorTestCase(unittest.TestCase):
 
         self.assertListEqual([({'name': 'First A'}, [({'name': 'Second '}, [({'parent_name': 'Second ', 'parent_parent_dim_1': 'A'}, [])])]), ({
                              'name': 'First B'}, [({'name': 'Second '}, [({'parent_name': 'Second ', 'parent_parent_dim_1': 'B'}, [])])])], res)
+
+    def test_len_context_variable(self):
+        res = BulkGenerator({
+            "version": "0.1.0",
+            "input": {},
+            "templates": [],
+            "output": {
+                "dimensions": ["*NUMERIC"],
+                "count": [8],
+                "generate": {"length": "{{len}}"},
+            }
+        }).generate()
+
+        self.assertEqual(8, len(res))
+        for e, _ in res:
+            self.assertEqual("8", e['length'])


### PR DESCRIPTION
This pr adds two new `len` attributes to the extended Jinja2 context which can be useful for giving the dimension a padding so that they are all equal length.

- `len` - count of elements this child will generate
- `dim.<x>.len` - count of items the x-th dimension has

### Example

`{{dim.1.zfill(dim.1.len|string|length)}}` can be used to pad the first dimension so that they are all of equal length