### PR TITLE
Bulk generate support for parts

### DIFF
--- a/inventree_bulk_plugin/BulkGenerator/BulkGenerator.py
+++ b/inventree_bulk_plugin/BulkGenerator/BulkGenerator.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import itertools
-from typing import Any, Callable, Iterable, Literal, Optional
+from typing import Any, Callable, Iterable, Literal, Optional, Union
 
 from jinja2.exceptions import TemplateError
 
@@ -59,15 +59,17 @@ class DimStr(str):
 @dataclass
 class FieldDefinition:
     name: str
-    field_type: Literal["text", "boolean", "number"] = "text"
+    field_type: Literal["text", "boolean", "number", "model"] = "text"
     cast_func: Callable[[str], Any] = None
     description: Optional[str] = None
     required: bool = False
+    model: Union[str, tuple[str, Union[dict, None]], None] = None
 
     type_casts = {
         "text": str,
         "boolean": str2bool,
         "number": str2int,
+        "model": str2int,
     }
 
     default_descriptions = {
@@ -82,8 +84,12 @@ class FieldDefinition:
         if not self.description and self.field_type in self.default_descriptions:
             self.description = self.default_descriptions.get(self.field_type, None)
 
+        if isinstance(self.model, str):
+            self.model = (self.model, None)
 
-ParseChildReturnType = list[tuple[dict[str, str], list["ParseChildReturnType"]]]
+
+ParseChildReturnElement = tuple[dict[str, str], list["ParseChildReturnType"]]
+ParseChildReturnType = list[ParseChildReturnElement]
 
 
 class BulkGenerator:

--- a/inventree_bulk_plugin/BulkGenerator/BulkGenerator.py
+++ b/inventree_bulk_plugin/BulkGenerator/BulkGenerator.py
@@ -74,7 +74,7 @@ ParseChildReturnType = list[ParseChildReturnElement]
 
 
 class BulkGenerator:
-    def __init__(self, inp, fields: dict[str, BaseFieldDefinition] = None):
+    def __init__(self, inp, fields: dict[str, BaseFieldDefinition]):
         self.inp = inp
         self.schema: BulkDefinitionSchema = None
         self.fields = fields
@@ -216,7 +216,7 @@ class BulkGenerator:
             "", field_type="object", fields=self.fields), generate)
 
         if len(missing_fields) > 0:
-            raise ValueError(f"{','.join(missing_fields)} are missing in generated keys.")
+            raise ValueError(f"'{','.join(missing_fields)}' are missing in generated keys.")
 
         def recursive_map(func: Callable[[Any, list[str]], Any], d: Any, path: list[str] = []):
             if isinstance(d, dict):

--- a/inventree_bulk_plugin/BulkGenerator/BulkGenerator.py
+++ b/inventree_bulk_plugin/BulkGenerator/BulkGenerator.py
@@ -180,17 +180,21 @@ class BulkGenerator:
         missing_fields = []
 
         def compile_templates(field: FieldType, generate, path: list[str] = []):
+            path_str = ".".join(map(str, path))
+
             if field.field_type == "object" and field.fields:
                 if not isinstance(generate, dict):
+                    if field.required:
+                        missing_fields.append(path_str)
                     return None
                 return {k: v for k, f in field.fields.items() if (v := compile_templates(f, generate.get(k, None), [*path, k])) is not None}
             elif field.field_type == "list" and field.items_type:
                 if not isinstance(generate, list):
+                    if field.required:
+                        missing_fields.append(path_str)
                     return None
                 return [v for i, f in enumerate(generate) if (v := compile_templates(field.items_type, f, [*path, i])) is not None]
             else:
-                path_str = ".".join(map(str, path))
-
                 # check required fields
                 if generate is None:
                     if field.required:

--- a/inventree_bulk_plugin/BulkGenerator/BulkGenerator.py
+++ b/inventree_bulk_plugin/BulkGenerator/BulkGenerator.py
@@ -181,8 +181,12 @@ class BulkGenerator:
 
         def compile_templates(field: FieldType, generate, path: list[str] = []):
             if field.field_type == "object" and field.fields:
+                if not isinstance(generate, dict):
+                    return None
                 return {k: v for k, f in field.fields.items() if (v := compile_templates(f, generate.get(k, None), [*path, k])) is not None}
             elif field.field_type == "list" and field.items_type:
+                if not isinstance(generate, list):
+                    return None
                 return [v for i, f in enumerate(generate) if (v := compile_templates(field.items_type, f, [*path, i])) is not None]
             else:
                 path_str = ".".join(map(str, path))
@@ -213,7 +217,7 @@ class BulkGenerator:
                 return render
 
         compiled_templates = compile_templates(BaseFieldDefinition(
-            "", field_type="object", fields=self.fields), generate)
+            "", field_type="object", fields=fields), generate)
 
         if len(missing_fields) > 0:
             raise ValueError(f"'{','.join(missing_fields)}' are missing in generated keys.")

--- a/inventree_bulk_plugin/BulkGenerator/BulkGenerator.py
+++ b/inventree_bulk_plugin/BulkGenerator/BulkGenerator.py
@@ -215,7 +215,10 @@ class BulkGenerator:
                         raise ValueError(
                             f"'{path_str}' is a required field, but template '{generate}' returned empty string")
                     if field.cast_func:
-                        return field.cast_func(v)
+                        try:
+                            return field.cast_func(v, field=field)
+                        except ValueError as e:
+                            raise ValueError(f"{path_str}: {e}")
                     return v
 
                 return render

--- a/inventree_bulk_plugin/BulkGenerator/template.py
+++ b/inventree_bulk_plugin/BulkGenerator/template.py
@@ -12,4 +12,4 @@ class Template:
         return True
 
     def compile(self):
-        return env.from_string(self.template_str)
+        return env.from_string(str(self.template_str))

--- a/inventree_bulk_plugin/BulkGenerator/utils.py
+++ b/inventree_bulk_plugin/BulkGenerator/utils.py
@@ -3,7 +3,13 @@ def version_tuple(v: str):
 
 
 def str2bool(text):
-    return str(text).lower() in ['1', 'y', 'yes', 't', 'true', 'ok', 'on', ]
+    string = str(text).lower()
+    if string in ['1', 'y', 'yes', 't', 'true', 'ok', 'on', ]:
+        return True
+    elif string in ['0', 'n', 'no', 'f', 'false', 'off', ]:
+        return False
+
+    raise ValueError(f"'{text}' cannot be casted to a boolean, either use 'true' or 'false'.")
 
 
 def str2int(text, default=None):

--- a/inventree_bulk_plugin/BulkGenerator/utils.py
+++ b/inventree_bulk_plugin/BulkGenerator/utils.py
@@ -17,3 +17,10 @@ def str2int(text, default=None):
         return int(text)
     except Exception:
         return default
+
+
+def str2float(text, default=None):
+    try:
+        return float(text)
+    except Exception:
+        return default

--- a/inventree_bulk_plugin/BulkGenerator/validations.py
+++ b/inventree_bulk_plugin/BulkGenerator/validations.py
@@ -49,7 +49,7 @@ class BulkDefinitionSchema(BaseModel):
                 for i, v in enumerate(value):
                     value[i] = _apply_input(v, f"{path}.{i}")
             elif isinstance(value, str):
-                use_extra_contexts = [r".*\.generate\.\w+$", r".*\.parent_name_match"]
+                use_extra_contexts = [r".*\.generate\..*$", r".*\.parent_name_match"]
 
                 try:
                     # if path ends with one in use_extra_contexts, only validate the template,

--- a/inventree_bulk_plugin/BulkGenerator/validations.py
+++ b/inventree_bulk_plugin/BulkGenerator/validations.py
@@ -15,7 +15,7 @@ class BulkDefinitionChild(BaseModel):
     parent_name_match: Optional[str] = "true"
     extends: Optional[str] = None
     dimensions: BulkDefinitionChildDimensions = []
-    generate: Optional[Dict[str, str]] = {}
+    generate: Optional[dict] = {}
     count: BulkDefinitionChildCount = []
     child: Optional["BulkDefinitionChild"] = None
     childs: Optional[List["BulkDefinitionChild"]] = []

--- a/inventree_bulk_plugin/InvenTreeBulkPlugin.py
+++ b/inventree_bulk_plugin/InvenTreeBulkPlugin.py
@@ -27,15 +27,21 @@ class InvenTreeBulkPlugin(AppMixin, PanelMixin, UrlsMixin, InvenTreePlugin):
             panels.append({
                 'title': 'Bulk creation',
                 'icon': 'fas fa-tools',
-                'content': '{% include "preact-page.html" with page="bulk-creation-panel" objectId=object.id objectType="STOCK_LOCATION" %}',
+                'content': '{% include "preact-page.html" with page="bulk-creation-panel" id="1" objectId=object.id objectType="STOCK_LOCATION" %}',
                 'description': 'Bulk creation tools',
             })
 
         if isinstance(view, CategoryDetail):
             panels.append({
-                'title': 'Bulk creation',
+                'title': 'Category bulk creation',
                 'icon': 'fas fa-tools',
-                'content': '{% include "preact-page.html" with page="bulk-creation-panel" objectId=object.id objectType="PART_CATEGORY" %}',
+                'content': '{% include "preact-page.html" with page="bulk-creation-panel" id="2" objectId=object.id objectType="PART_CATEGORY" %}',
+                'description': 'Bulk creation tools',
+            })
+            panels.append({
+                'title': 'Part bulk creation',
+                'icon': 'fas fa-tools',
+                'content': '{% include "preact-page.html" with page="bulk-creation-panel" id="3" objectId=object.id objectType="PART" %}',
                 'description': 'Bulk creation tools',
             })
 

--- a/inventree_bulk_plugin/api.py
+++ b/inventree_bulk_plugin/api.py
@@ -12,7 +12,7 @@ from pydantic import ValidationError
 from InvenTree.filters import SEARCH_ORDER_FILTER
 
 from .bulkcreate_objects import bulkcreate_objects
-from .serializers import TemplateSerializer, BulkCreateObjectSerializer
+from .serializers import TemplateSerializer, BulkCreateObjectSerializer, BulkCreateObjectDetailSerializer
 from .models import BulkCreationTemplate
 from .BulkGenerator.utils import str2bool
 from .BulkGenerator.BulkGenerator import BulkGenerator
@@ -102,7 +102,7 @@ class BulkCreate(APIView):
             )
 
         bulkcreate_object = bulkcreate_object_class(request)
-        results = BulkCreateObjectSerializer(bulkcreate_object).data
+        results = BulkCreateObjectDetailSerializer(bulkcreate_object).data
         return Response(results)
 
     def post(self, request: Request):

--- a/inventree_bulk_plugin/api.py
+++ b/inventree_bulk_plugin/api.py
@@ -103,15 +103,15 @@ class BulkCreate(APIView):
         if not schema:
             return Response({"error": "BulkDefinitionSchema not provided via 'template' property."}, status=status.HTTP_400_BAD_REQUEST)
 
-        bulkcreate_object = bulkcreate_object_class(request.query_params)
-
-        ctx = bulkcreate_object.get_context()
-
-        # catch error responses
-        if isinstance(ctx, Response):
-            return ctx
-
         try:
+            bulkcreate_object = bulkcreate_object_class(request.query_params)
+
+            ctx = bulkcreate_object.get_context()
+
+            # catch error responses
+            if isinstance(ctx, Response):
+                return ctx
+
             if not isinstance(schema, dict):
                 schema = json.loads(schema)
             bg = BulkGenerator(schema, fields=bulkcreate_object.fields).generate(ctx)

--- a/inventree_bulk_plugin/api.py
+++ b/inventree_bulk_plugin/api.py
@@ -108,10 +108,6 @@ class BulkCreate(APIView):
 
             ctx = bulkcreate_object.get_context()
 
-            # catch error responses
-            if isinstance(ctx, Response):
-                return ctx
-
             if not isinstance(schema, dict):
                 schema = json.loads(schema)
             bg = BulkGenerator(schema, fields=bulkcreate_object.fields).generate(ctx)
@@ -122,13 +118,11 @@ class BulkCreate(APIView):
 
         # only create if create query param is set
         if create_objects:
-            objects = bulkcreate_object.create_objects(bg)
-
-            # catch error responses
-            if isinstance(objects, Response):  # pragma: no cover
-                return objects
-
-            return Response([obj.pk for obj in objects], status=status.HTTP_201_CREATED)
+            try:
+                objects = bulkcreate_object.create_objects(bg)
+                return Response([obj.pk for obj in objects], status=status.HTTP_201_CREATED)
+            except Exception as e:  # pragma: no cover
+                return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(bg)
 

--- a/inventree_bulk_plugin/api.py
+++ b/inventree_bulk_plugin/api.py
@@ -6,6 +6,7 @@ from rest_framework.authentication import SessionAuthentication, BasicAuthentica
 from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework.request import Request
 from pydantic import ValidationError
 
 from InvenTree.filters import SEARCH_ORDER_FILTER
@@ -83,7 +84,7 @@ class BulkCreate(APIView):
     authentication_classes = authentication_classes
     permission_classes = [permissions.IsAuthenticated]
 
-    def get(self, request):
+    def get(self, request: Request):
         template_type = request.query_params.get("template_type", None)
 
         # return all bulk create objects
@@ -100,11 +101,11 @@ class BulkCreate(APIView):
                 status=status.HTTP_400_BAD_REQUEST
             )
 
-        bulkcreate_object = bulkcreate_object_class(request.query_params)
+        bulkcreate_object = bulkcreate_object_class(request)
         results = BulkCreateObjectSerializer(bulkcreate_object).data
         return Response(results)
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request):
         create_objects = str2bool(request.query_params.get("create", "false"))
         template_type = request.data.get("template_type", None)
         schema = request.data.get("template", None)
@@ -121,7 +122,7 @@ class BulkCreate(APIView):
             return Response({"error": "BulkDefinitionSchema not provided via 'template' property."}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            bulkcreate_object = bulkcreate_object_class(request.query_params)
+            bulkcreate_object = bulkcreate_object_class(request)
 
             ctx = bulkcreate_object.get_context()
 

--- a/inventree_bulk_plugin/bulkcreate_objects.py
+++ b/inventree_bulk_plugin/bulkcreate_objects.py
@@ -131,7 +131,7 @@ class FieldDefinition(BaseFieldDefinition):
         if url := hardcoded_models[model_table]:
             return reverse(url)
 
-        return None
+        return None  # pragma: no cover
 
 
 ModelType = TypeVar("ModelType")

--- a/inventree_bulk_plugin/bulkcreate_objects.py
+++ b/inventree_bulk_plugin/bulkcreate_objects.py
@@ -404,9 +404,10 @@ class PartBulkCreateObject(BulkCreateObject[Part]):
             # maybe use already saved image with same url
             if image in self.part_images and isinstance(self.part_images[image], str):
                 image = self.part_images[image]
-            elif not (Path(settings.MEDIA_ROOT.joinpath(image))).is_file():
-                # try to use local image which is not available
-                raise ValueError(f"Image '{image}' for part '{data[0]['name']}' does not exist")
+            elif not re.match(r"^(?:[a-z+]+:)?//", image):
+                # try use local image
+                if not (Path(settings.MEDIA_ROOT.joinpath(image))).is_file():
+                    raise ValueError(f"Image '{image}' for part '{data[0]['name']}' does not exist")
             data[0]["image"] = image
 
         # create part

--- a/inventree_bulk_plugin/bulkcreate_objects.py
+++ b/inventree_bulk_plugin/bulkcreate_objects.py
@@ -1,12 +1,30 @@
 from typing import Generic, Literal, TypeVar, Union
+from django.db import transaction
+from django.apps import apps
 from rest_framework.response import Response
 from rest_framework import status
-from inventree_bulk_plugin.BulkGenerator.utils import str2bool
 
 from stock.models import StockLocation
-from part.models import PartCategory
+from part.models import PartCategory, Part
 
-from .BulkGenerator.BulkGenerator import FieldDefinition, ParseChildReturnType
+from .BulkGenerator.utils import str2bool
+from .BulkGenerator.BulkGenerator import FieldDefinition, ParseChildReturnElement, ParseChildReturnType
+
+
+def get_model(model_name: str):
+    try:
+        (app, mdl) = model_name.lower().strip().split('.')
+    except ValueError:
+        return None
+
+    app_models = apps.all_models.get(app, None)
+
+    if app_models is None:
+        return None
+
+    model = app_models.get(mdl, None)
+
+    return model
 
 
 ModelType = TypeVar("ModelType")
@@ -15,34 +33,58 @@ ModelType = TypeVar("ModelType")
 class BulkCreateObject(Generic[ModelType]):
     name: str
     template_type: str
-    generate_type: Literal["tree"] = "tree"
+    generate_type: Literal["tree", "single"] = "tree"
     model: ModelType
     fields: dict[str, FieldDefinition]
 
     def __init__(self, query_params: dict[str, str]) -> None:
         self.query_params = query_params
 
+        for field in self.fields.values():
+            if field.model and not hasattr(field, "model_class"):
+                model = get_model(field.model[0])
+                if not model:
+                    raise ValueError(f"Model '{field.model[0]}' not found.")
+
+                setattr(field, "model_class", model)
+
+    def create_object(self, data: ParseChildReturnElement, **kwargs):
+        properties = {}
+        for k, v in data[0].items():
+            if field := self.fields.get(k, None):
+                if field.model:
+                    model = getattr(field, "model_class")
+                    obj = model.objects.get(pk=v)
+                    v = obj
+                properties[k] = v
+
+        return self.model.objects.create(**{**kwargs, **properties})
+
     def create_objects(self, objects: ParseChildReturnType) -> list[ModelType]:
         if self.generate_type == "tree":
             created_objects = []
 
-            def recursive_bulk_create(parent, childs):
+            def recursive_bulk_create(parent: ModelType, childs: ParseChildReturnType):
                 for c in childs:
-                    properties = {}
-                    for k, v in c[0].items():
-                        if k in self.fields:
-                            properties[k] = v
-
-                    obj = self.model.objects.create(
-                        **properties,
-                        parent=parent
-                    )
+                    obj = self.create_object(c, parent=parent)
                     created_objects.append(obj)
 
                     recursive_bulk_create(obj, c[1])
 
             try:
-                recursive_bulk_create(self.parent, objects)
+                with transaction.atomic():
+                    recursive_bulk_create(self.parent, objects)
+                return created_objects
+            except Exception as e:  # pragma: no cover
+                return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        if self.generate_type == "single":
+            created_objects = []
+
+            try:
+                with transaction.atomic():
+                    for o in objects:
+                        created_objects.append(self.create_object(o))
                 return created_objects
             except Exception as e:  # pragma: no cover
                 return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
@@ -102,7 +144,65 @@ class PartCategoryBulkCreateObject(BulkCreateObject[PartCategory]):
     }
 
 
+class PartBulkCreateObject(BulkCreateObject[Part]):
+    name = "Part"
+    template_type = "PART"
+    generate_type = "single"
+    model = Part
+
+    fields = {
+        "name": FieldDefinition("Name", required=True),
+        "description": FieldDefinition("Description"),
+        "category": FieldDefinition("Category", field_type="model", model="part.PartCategory", description="If not set, defaults to current category"),
+        "variant_of": FieldDefinition("Variant of", field_type="model", model=("part.Part", {"is_template": True})),
+        "keywords": FieldDefinition("Keywords"),
+        "IPN": FieldDefinition("IPN"),
+        "revision": FieldDefinition("Revision"),
+        "is_template": FieldDefinition("Is Template", field_type="boolean"),
+        "link": FieldDefinition("Link"),
+        "default_location": FieldDefinition("Default Location", field_type="model", model="stock.StockLocation"),
+        "default_supplier": FieldDefinition("Default Supplier part", field_type="model", model="company.SupplierPart"),
+        "default_expiry": FieldDefinition("Default Expiry", field_type="number", description="Expiry time (in days) for stock items of this part"),
+        "minimum_stock": FieldDefinition("Minimum Stock", field_type="number", description="Minimum allowed stock level"),
+        "units": FieldDefinition("Units", description="Units of measure for this part"),
+        "salable": FieldDefinition("Salable", field_type="boolean"),
+        "assembly": FieldDefinition("Assembly", field_type="boolean"),
+        "component": FieldDefinition("Component", field_type="boolean"),
+        "purchaseable": FieldDefinition("Purchaseable", field_type="boolean"),
+        "trackable": FieldDefinition("Trackable", field_type="boolean"),
+        "active": FieldDefinition("Active", field_type="boolean"),
+        "virtual": FieldDefinition("Virtual", field_type="boolean"),
+        "notes": FieldDefinition("Notes"),
+        "responsible": FieldDefinition("Responsible", field_type="model", model="auth.user"),
+        "image": FieldDefinition("Image"),
+
+        # TODO
+        # "creation_user"
+        # "parameters"
+        # "initial_stock"
+        # "initial_supplier"
+        # "attachments"
+    }
+
+    def create_object(self, data: ParseChildReturnElement):
+        return super().create_object(data, category=self.category)
+
+    def get_context(self) -> dict | Response:
+        parent_id = self.query_params.get("parent_id", None)
+        ctx = super().get_context()
+
+        if parent_id:
+            try:
+                category = PartCategory.objects.get(pk=parent_id)
+                self.category = category
+                category_dict = {key: getattr(category, key) for key in self.fields.keys() if hasattr(category, key)}
+                return {**ctx, "category": category_dict}
+            except self.model.DoesNotExist:
+                return Response({"error": f"category with id '{parent_id}' cannot be found"}, status=status.HTTP_404_NOT_FOUND)
+
+
 bulkcreate_objects: dict[str, type[BulkCreateObject]] = {
     "STOCK_LOCATION": StockLocationBulkCreateObject,
     "PART_CATEGORY": PartCategoryBulkCreateObject,
+    "PART": PartBulkCreateObject,
 }

--- a/inventree_bulk_plugin/bulkcreate_objects.py
+++ b/inventree_bulk_plugin/bulkcreate_objects.py
@@ -7,8 +7,11 @@ from rest_framework.request import Request
 
 from stock.models import StockLocation
 from part.models import PartCategory, Part, PartParameter, PartParameterTemplate, PartCategoryParameterTemplate, PartAttachment
+from company.models import Company, ManufacturerPart, SupplierPart
+from stock.models import StockItem
+from InvenTree.status_codes import StockStatus
 
-from .BulkGenerator.utils import str2bool, str2int
+from .BulkGenerator.utils import str2bool, str2int, str2float
 from .BulkGenerator.BulkGenerator import BaseFieldDefinition, ParseChildReturnElement, ParseChildReturnType
 
 
@@ -31,7 +34,7 @@ def get_model(model_name: str):
 @dataclass
 class FieldDefinition(BaseFieldDefinition):
     name: str
-    field_type: Literal["text", "boolean", "number", "model", "list", "object"] = "text"
+    field_type: Literal["text", "boolean", "number", "float", "model", "list", "object"] = "text"
     cast_func: Callable[[str], Any] = None
     description: Optional[str] = None
     required: bool = False
@@ -45,12 +48,14 @@ class FieldDefinition(BaseFieldDefinition):
         "text": str,
         "boolean": str2bool,
         "number": str2int,
+        "float": str2float,
         "model": str2int,
     }
 
     default_descriptions = {
         "boolean": "This must evaluate to something that can be casted to a boolean (e.g. 'true' or 'false').",
         "number": "This must evaluate to something that can be casted as number.",
+        "float": "This must evaluate to something that can be casted as float (e.g. '3.1415').",
     }
 
     def __post_init__(self):
@@ -68,6 +73,13 @@ class FieldDefinition(BaseFieldDefinition):
             if not model_class:
                 raise ValueError(f"Model '{self.model[0]}' not found.")
             self.model = (self.model[0], self.model[1], model_class)
+
+
+def get_model_instance(model: Model, pk, limit_choices={}, error_msg=""):
+    try:
+        return model.objects.get(pk=pk, **limit_choices)
+    except model.DoesNotExist:
+        raise ValueError(f"Model '{model._meta}' where {({'pk': pk,**limit_choices})} not found {error_msg}")
 
 
 ModelType = TypeVar("ModelType")
@@ -88,11 +100,8 @@ class BulkCreateObject(Generic[ModelType]):
         for k, v in data[0].items():
             if field := self.fields.get(k, None):
                 if field.model:
-                    model_name, limit_choices, model = field.model
-                    try:
-                        v = model.objects.get(pk=v, **limit_choices)
-                    except model.DoesNotExist:
-                        raise ValueError(f"Model '{model_name}' where {({'pk': v,**limit_choices})} not found")
+                    _, limit_choices, model = field.model
+                    v = get_model_instance(model, v, limit_choices)
                 properties[k] = v
 
         return self.model.objects.create(**{**kwargs, **properties})
@@ -191,8 +200,7 @@ class PartBulkCreateObject(BulkCreateObject[Part]):
         "revision": FieldDefinition("Revision"),
         "is_template": FieldDefinition("Is Template", field_type="boolean"),
         "link": FieldDefinition("Link"),
-        "default_location": FieldDefinition("Default Location", field_type="model", model="stock.StockLocation"),
-        "default_supplier": FieldDefinition("Default Supplier part", field_type="model", model="company.SupplierPart"),
+        "default_location": FieldDefinition("Default Location", field_type="model", model=("stock.StockLocation", {"structural": False})),
         "default_expiry": FieldDefinition("Default Expiry", field_type="number", description="Expiry time (in days) for stock items of this part"),
         "minimum_stock": FieldDefinition("Minimum Stock", field_type="number", description="Minimum allowed stock level"),
         "units": FieldDefinition("Units", description="Units of measure for this part"),
@@ -233,16 +241,55 @@ class PartBulkCreateObject(BulkCreateObject[Part]):
                 },
                 required=True,
             )),
-
-        # TODO
-        # "initial_stock"
-        # "initial_supplier"
+        "supplier": FieldDefinition(
+            "Supplier",
+            field_type="object",
+            fields={
+                "supplier": FieldDefinition("Supplier", field_type="model", model=("company.Company", {'is_supplier': True}), required=True),
+                "SKU": FieldDefinition("SKU", required=True),
+                "description": FieldDefinition("Description"),
+                "link": FieldDefinition("Link"),
+                "note": FieldDefinition("Note"),
+                "packaging": FieldDefinition("Packaging"),
+                "pack_quantity": FieldDefinition("Pack Quantity", description="Total quantity supplied in a single pack. Leave empty for single items."),
+                "multiple": FieldDefinition("Multiple", field_type="number"),
+                "_make_default": FieldDefinition("Make default", field_type="boolean", description="Make this supplier part the default for this part."),
+            }),
+        "manufacturer": FieldDefinition(
+            "Manufacturer",
+            field_type="object",
+            fields={
+                "manufacturer": FieldDefinition("Manufacturer", field_type="model", model=("company.Company", {'is_manufacturer': True}), required=True),
+                "MPN": FieldDefinition("MPN", required=True),
+                "description": FieldDefinition("Description"),
+                "link": FieldDefinition("Link"),
+            }),
+        "stock": FieldDefinition(
+            "Stock",
+            field_type="object",
+            fields={
+                "quantity": FieldDefinition("Quantity", field_type="float", required=True),
+                "location": FieldDefinition("Location", field_type="model", model=("stock.StockLocation", {"structural": False}), required=True),
+                "batch": FieldDefinition("Batch"),
+                "link": FieldDefinition("Link"),
+                "review_needed": FieldDefinition("Review needed", field_type="boolean"),
+                "delete_on_deplete": FieldDefinition("Delete on deplete", field_type="boolean"),
+                "status": FieldDefinition("Status", description="Either define the numeric status code or the name in all uppercase, like OK, DAMAGED, ..."),
+                "notes": FieldDefinition("Note"),
+                "packaging": FieldDefinition("Packaging"),
+                "purchase_price": FieldDefinition("Purchase price"),
+                "purchase_price_currency": FieldDefinition("Currency"),
+            }
+        ),
     }
 
     def create_object(self, data: ParseChildReturnElement):
         # remove relations from data to create them separately
         parameters = data[0].pop("parameters", [])
         attachments = data[0].pop("attachments", [])
+        supplier_data = data[0].pop("supplier", None)
+        manufacturer_data = data[0].pop("manufacturer", None)
+        stock_data = data[0].pop("stock", None)
 
         # create part
         part = super().create_object(
@@ -253,12 +300,7 @@ class PartBulkCreateObject(BulkCreateObject[Part]):
 
         # create parameters
         for parameter in parameters:
-            try:
-                template = PartParameterTemplate.objects.get(pk=parameter["template"])
-            except PartParameterTemplate.DoesNotExist:
-                raise ValueError(
-                    f"Part parameter template with pk={parameter['template']} for {part.name} does not exist.")
-
+            template = get_model_instance(PartParameterTemplate, parameter["template"], f"for {part.name}")
             PartParameter.objects.create(part=part, template=template, data=parameter['value'])
 
         # create attachments
@@ -270,6 +312,64 @@ class PartBulkCreateObject(BulkCreateObject[Part]):
                 comment=attachment["comment"],
                 user=self.request.user
             )
+
+        # create manufacturer part
+        manufacturer_part = None
+        if manufacturer_data:
+            manufacturer_pk = manufacturer_data.pop("manufacturer", None)
+            manufacturer = get_model_instance(Company, manufacturer_pk, {"is_manufacturer": True}, f"for {part.name}")
+
+            manufacturer_part = ManufacturerPart.objects.create(
+                part=part,
+                manufacturer=manufacturer,
+                **manufacturer_data,
+            )
+
+        # create supplier part
+        supplier_part = None
+        if supplier_data:
+            supplier_pk = supplier_data.pop("supplier", None)
+            _make_default = supplier_data.pop("_make_default", False)
+            supplier = get_model_instance(Company, supplier_pk, {"is_supplier": True}, f"for {part.name}")
+
+            supplier_part = SupplierPart.objects.create(
+                part=part,
+                supplier=supplier,
+                manufacturer_part=manufacturer_part,
+                **supplier_data,
+            )
+
+            # if wanted, make this supplier part the default for this part
+            if _make_default:
+                part.default_supplier = supplier_part
+                part.save()
+
+        # create initial stock
+        if stock_data:
+            location_pk = stock_data.pop("location", None)
+            status = stock_data.pop("status", None)
+            location = get_model_instance(StockLocation, location_pk, {}, f"for {part.name}")
+
+            # convert status to numeric StatusCode value
+            if status:
+                if (status_int := str2int(status)) is not None:
+                    status_code = getattr(StockStatus.values(status_int), "value", None)
+                else:
+                    status_code = StockStatus.names().get(status, None)
+
+                if status_code is None:
+                    raise ValueError(
+                        f"Stock status '{status}' for part '{part.name}' not found, use one of {', '.join(StockStatus.names().keys())}")
+
+                stock_data["status"] = status_code
+
+            stock_item = StockItem(
+                part=part,
+                location=location,
+                supplier_part=supplier_part,
+                **stock_data,
+            )
+            stock_item.save(user=self.request.user)
 
         return part
 

--- a/inventree_bulk_plugin/bulkcreate_objects.py
+++ b/inventree_bulk_plugin/bulkcreate_objects.py
@@ -280,7 +280,7 @@ class PartBulkCreateObject(BulkCreateObject[Part]):
                 if len(parameters) == 0:
                     return [{"template": "", "value": ""}]
 
-                return [{"template": c.parameter_template.id, "value": c.default_value} for c in parameters]
+                return [{"template": str(c.parameter_template.id), "value": c.default_value} for c in parameters]
             except Exception:
                 pass
 

--- a/inventree_bulk_plugin/bulkcreate_objects.py
+++ b/inventree_bulk_plugin/bulkcreate_objects.py
@@ -218,9 +218,10 @@ class PartBulkCreateObject(BulkCreateObject[Part]):
             try:
                 category = PartCategory.objects.get(pk=parent_id)
                 self.category = category
-                category_dict = {key: getattr(category, key) for key in self.fields.keys() if hasattr(category, key)}
+                category_dict = {key: getattr(category, key)
+                                 for key in PartCategoryBulkCreateObject.fields.keys() if hasattr(category, key)}
                 return {**ctx, "category": category_dict}
-            except self.model.DoesNotExist:
+            except PartCategory.DoesNotExist:
                 raise ValueError(f"category with id '{parent_id}' cannot be found")
 
 

--- a/inventree_bulk_plugin/bulkcreate_objects.py
+++ b/inventree_bulk_plugin/bulkcreate_objects.py
@@ -177,7 +177,7 @@ class PartCategoryBulkCreateObject(BulkCreateObject[PartCategory]):
     fields = {
         "name": FieldDefinition("Name", required=True),
         "description": FieldDefinition("Description"),
-        "default_location_id": FieldDefinition("Default location", field_type="number", description="This must evaluate to a valid stock location id."),
+        "default_location": FieldDefinition("Default location", field_type="model", model="stock.StockLocation"),
         "default_keywords": FieldDefinition("Default keywords"),
         "structural": FieldDefinition("Structural", field_type="boolean"),
         "icon": FieldDefinition("Icon"),

--- a/inventree_bulk_plugin/bulkcreate_objects.py
+++ b/inventree_bulk_plugin/bulkcreate_objects.py
@@ -212,17 +212,21 @@ class PartBulkCreateObject(BulkCreateObject[Part]):
 
     def get_context(self) -> dict:
         parent_id = self.query_params.get("parent_id", None)
+        self.category = None
+
         ctx = super().get_context()
 
-        if parent_id:
-            try:
-                category = PartCategory.objects.get(pk=parent_id)
-                self.category = category
-                category_dict = {key: getattr(category, key)
-                                 for key in PartCategoryBulkCreateObject.fields.keys() if hasattr(category, key)}
-                return {**ctx, "category": category_dict}
-            except PartCategory.DoesNotExist:
-                raise ValueError(f"category with id '{parent_id}' cannot be found")
+        if not parent_id:
+            return ctx
+
+        try:
+            category = PartCategory.objects.get(pk=parent_id)
+            self.category = category
+            category_dict = {key: getattr(category, key)
+                             for key in PartCategoryBulkCreateObject.fields.keys() if hasattr(category, key)}
+            return {**ctx, "category": category_dict}
+        except PartCategory.DoesNotExist:
+            raise ValueError(f"category with id '{parent_id}' cannot be found")
 
 
 bulkcreate_objects: dict[str, type[BulkCreateObject]] = {

--- a/inventree_bulk_plugin/frontend/src/components/BulkDefinitionChildSchemaBuilder.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/BulkDefinitionChildSchemaBuilder.tsx
@@ -181,7 +181,6 @@ export function BulkDefinitionChildSchemaBuilder({
           name: "",
           description: null,
           required: true,
-          model: null,
           field_type: "object",
           fields: bulkGenerateInfo.fields,
         }}
@@ -206,8 +205,8 @@ export function BulkDefinitionChildSchemaBuilder({
                     />
                   </div>
                   <div class="p-1">
-                    <button onClick={removeChild(i)} class="btn btn-outline-danger">
-                      X
+                    <button onClick={removeChild(i)} class="btn btn-sm btn-outline-danger">
+                      <i class="fa fa-trash"></i>
                     </button>
                   </div>
                 </div>

--- a/inventree_bulk_plugin/frontend/src/components/BulkDefinitionChildSchemaBuilder.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/BulkDefinitionChildSchemaBuilder.tsx
@@ -164,32 +164,36 @@ export function BulkDefinitionChildSchemaBuilder({
         onInput={setDimension("count")}
       />
 
-      <h6
-        class={`user-select-none collapsable-heading ${outputAdvancedState ? "active" : ""}`}
-        role="button"
-        onClick={onOutputAdvanceToggle}
-      >
-        Advanced
-      </h6>
-      <div class="collapse" id={outputAdvancedId}>
-        <Input
-          label="Parent name match"
-          tooltip="First child that matches the parent name matcher will be chosen for generating the childs for a specific parent. Must evaluate to something that can be casted to a boolean."
-          type="text"
-          value={childSchema.parent_name_match || ""}
-          onInput={setValue("parent_name_match")}
-        />
-        {extendsKeys && (
-          <Input
-            label="Extends"
-            tooltip="Choose to extend from a template"
-            type="select"
-            options={extendsKeys}
-            value={childSchema.extends || ""}
-            onInput={setValue("extends")}
-          />
-        )}
-      </div>
+      {bulkGenerateInfo.generate_type === "tree" && (
+        <>
+          <h6
+            class={`user-select-none collapsable-heading ${outputAdvancedState ? "active" : ""}`}
+            role="button"
+            onClick={onOutputAdvanceToggle}
+          >
+            Advanced
+          </h6>
+          <div class="collapse" id={outputAdvancedId}>
+            <Input
+              label="Parent name match"
+              tooltip="First child that matches the parent name matcher will be chosen for generating the childs for a specific parent. Must evaluate to something that can be casted to a boolean."
+              type="text"
+              value={childSchema.parent_name_match || ""}
+              onInput={setValue("parent_name_match")}
+            />
+            {extendsKeys && (
+              <Input
+                label="Extends"
+                tooltip="Choose to extend from a template"
+                type="select"
+                options={extendsKeys}
+                value={childSchema.extends || ""}
+                onInput={setValue("extends")}
+              />
+            )}
+          </div>
+        </>
+      )}
 
       <div class="mt-3">
         <Tooltip
@@ -227,31 +231,35 @@ export function BulkDefinitionChildSchemaBuilder({
         </div>
       )}
 
-      <h5 class="mt-3">Childs</h5>
-      <div class="ms-3">
-        {childSchema.childs?.map((child, i) => (
-          <div class="card mb-2">
-            <div class="d-flex justify-content-between">
-              <div class="col p-3">
-                <BulkDefinitionChildSchemaBuilder
-                  childSchema={child}
-                  setChildSchema={setChildChildSchema(i)}
-                  bulkGenerateInfo={bulkGenerateInfo}
-                  extendsKeys={extendsKeys}
-                />
+      {bulkGenerateInfo.generate_type === "tree" && (
+        <>
+          <h5 class="mt-3">Childs</h5>
+          <div class="ms-3">
+            {childSchema.childs?.map((child, i) => (
+              <div class="card mb-2">
+                <div class="d-flex justify-content-between">
+                  <div class="col p-3">
+                    <BulkDefinitionChildSchemaBuilder
+                      childSchema={child}
+                      setChildSchema={setChildChildSchema(i)}
+                      bulkGenerateInfo={bulkGenerateInfo}
+                      extendsKeys={extendsKeys}
+                    />
+                  </div>
+                  <div class="p-1">
+                    <button onClick={removeChild(i)} class="btn btn-outline-danger">
+                      X
+                    </button>
+                  </div>
+                </div>
               </div>
-              <div class="p-1">
-                <button onClick={removeChild(i)} class="btn btn-outline-danger">
-                  X
-                </button>
-              </div>
-            </div>
+            ))}
           </div>
-        ))}
-      </div>
-      <button onClick={addChild} class="btn btn-outline-primary btn-sm">
-        Add child
-      </button>
+          <button onClick={addChild} class="btn btn-outline-primary btn-sm">
+            Add child
+          </button>
+        </>
+      )}
     </div>
   );
 }

--- a/inventree_bulk_plugin/frontend/src/components/BulkDefinitionChildSchemaBuilder.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/BulkDefinitionChildSchemaBuilder.tsx
@@ -1,10 +1,11 @@
 import { JSX } from "preact";
-import { useState, useCallback, useEffect, useMemo, useId, StateUpdater } from "preact/hooks";
+import { useState, useCallback, useEffect, useId, StateUpdater } from "preact/hooks";
 
+import { GenerateKeysObject } from "./GenerateKeys";
 import { Input } from "./Input";
 import { Tooltip } from "./Tooltip";
 import { defaultSchema } from "../utils/constants";
-import { BulkDefinitionChild, BulkGenerateInfo } from "../utils/types";
+import { BulkDefinitionChild, BulkGenerateInfo, FieldType } from "../utils/types";
 
 import "./BulkDefinitionChildSchemaBuilder.css";
 
@@ -43,35 +44,8 @@ export function BulkDefinitionChildSchemaBuilder({
   );
 
   // set a generated value by key and event
-  const setGenerateValue = useCallback(
-    (key: string) => (value: string) => setChildSchema((s) => ({ ...s, generate: { ...s.generate, [key]: value } })),
-    [setChildSchema],
-  );
-
-  const remainingGenerateKeys = useMemo(() => {
-    const currentKeys = Object.keys(childSchema?.generate || {});
-    return Object.entries(bulkGenerateInfo.fields).filter(([k]) => !currentKeys.includes(k));
-  }, [childSchema?.generate, bulkGenerateInfo.fields]);
-
-  const [remainingGenerateKeysValue, setRemainingGenerateKeysValue] = useState("");
-
-  const handleAddGenerateKey = useCallback(
-    (key: string) => {
-      if (key !== "") {
-        setGenerateValue(key)("");
-        setRemainingGenerateKeysValue("");
-      }
-    },
-    [setGenerateValue, setRemainingGenerateKeysValue],
-  );
-
-  const handleDeleteGenerateKey = useCallback(
-    (key: string) => () => {
-      setChildSchema((s) => ({
-        ...s,
-        generate: Object.fromEntries(Object.entries(s.generate).filter(([k]) => k !== key)),
-      }));
-    },
+  const setGenerate: StateUpdater<Record<string, FieldType>> = useCallback(
+    (value) => setChildSchema((s) => ({ ...s, generate: typeof value === "function" ? value(s.generate) : value })),
     [setChildSchema],
   );
 
@@ -202,34 +176,19 @@ export function BulkDefinitionChildSchemaBuilder({
           <h5>Generate</h5>
         </Tooltip>
       </div>
-      {Object.entries(bulkGenerateInfo.fields)
-        .filter(([key]) => childSchema.generate[key] !== undefined)
-        .map(([key, { name, required, description }]) => (
-          <Input
-            label={name}
-            tooltip={description || undefined}
-            type="text"
-            value={childSchema.generate[key]}
-            onInput={(e: JSX.TargetedEvent<HTMLInputElement, Event>) => setGenerateValue(key)(e.currentTarget.value)}
-            onDelete={required ? undefined : handleDeleteGenerateKey(key)}
-          />
-        ))}
-      {remainingGenerateKeys.length > 0 && (
-        <div style="display: flex; max-width: 200px;">
-          <select
-            class="form-select form-select-sm"
-            value={remainingGenerateKeysValue}
-            onInput={(e) => handleAddGenerateKey(e.currentTarget.value)}
-          >
-            <option selected value="">
-              Add key
-            </option>
-            {remainingGenerateKeys.map(([key, { name }]) => (
-              <option value={key}>{name}</option>
-            ))}
-          </select>
-        </div>
-      )}
+      <GenerateKeysObject
+        fieldsDefinition={{
+          name: "",
+          description: null,
+          required: true,
+          model: null,
+          field_type: "object",
+          fields: bulkGenerateInfo.fields,
+        }}
+        fields={childSchema.generate}
+        setFields={setGenerate}
+        showCard={false}
+      />
 
       {bulkGenerateInfo.generate_type === "tree" && (
         <>

--- a/inventree_bulk_plugin/frontend/src/components/BulkDefinitionSchemaBuilder.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/BulkDefinitionSchemaBuilder.tsx
@@ -121,55 +121,59 @@ export function BulkDefinitionSchemaBuilder({ schema, setSchema, bulkGenerateInf
         </div>
       </div>
 
-      <div class="card mt-2">
-        <div class="card-header">
-          <h5
-            class="mb-0 user-select-none"
-            role="button"
-            data-bs-toggle="collapse"
-            data-bs-target={`#accordion-${accordionId}-templates`}
-          >
-            Templates
-          </h5>
-        </div>
+      {bulkGenerateInfo.generate_type === "tree" && (
+        <>
+          <div class="card mt-2">
+            <div class="card-header">
+              <h5
+                class="mb-0 user-select-none"
+                role="button"
+                data-bs-toggle="collapse"
+                data-bs-target={`#accordion-${accordionId}-templates`}
+              >
+                Templates
+              </h5>
+            </div>
 
-        <div id={`accordion-${accordionId}-templates`} class="collapse">
-          <div class="card-body">
-            {schema.templates.map((template, i) => (
-              <div class="card mb-2">
-                <div class="d-flex justify-content-between">
-                  <div class="col p-3">
-                    {template !== null && (
-                      <Input
-                        label="Template name"
-                        type="text"
-                        value={template.name}
-                        onInput={(e: JSX.TargetedEvent<HTMLInputElement, Event>) =>
-                          setTemplate(i)((t) => ({ ...t, name: e.currentTarget.value }))
-                        }
-                      />
-                    )}
-                    <BulkDefinitionChildSchemaBuilder
-                      childSchema={template}
-                      setChildSchema={setTemplate(i) as unknown as StateUpdater<BulkDefinitionChild>}
-                      bulkGenerateInfo={bulkGenerateInfo}
-                      extendsKeys={extendsKeys}
-                    />
+            <div id={`accordion-${accordionId}-templates`} class="collapse">
+              <div class="card-body">
+                {schema.templates.map((template, i) => (
+                  <div class="card mb-2">
+                    <div class="d-flex justify-content-between">
+                      <div class="col p-3">
+                        {template !== null && (
+                          <Input
+                            label="Template name"
+                            type="text"
+                            value={template.name}
+                            onInput={(e: JSX.TargetedEvent<HTMLInputElement, Event>) =>
+                              setTemplate(i)((t) => ({ ...t, name: e.currentTarget.value }))
+                            }
+                          />
+                        )}
+                        <BulkDefinitionChildSchemaBuilder
+                          childSchema={template}
+                          setChildSchema={setTemplate(i) as unknown as StateUpdater<BulkDefinitionChild>}
+                          bulkGenerateInfo={bulkGenerateInfo}
+                          extendsKeys={extendsKeys}
+                        />
+                      </div>
+                      <div class="p-1">
+                        <button onClick={removeTemplate(i)} class="btn btn-outline-danger">
+                          X
+                        </button>
+                      </div>
+                    </div>
                   </div>
-                  <div class="p-1">
-                    <button onClick={removeTemplate(i)} class="btn btn-outline-danger">
-                      X
-                    </button>
-                  </div>
-                </div>
+                ))}
+                <button onClick={addTemplate} class="btn btn-outline-primary btn-sm">
+                  Add template
+                </button>
               </div>
-            ))}
-            <button onClick={addTemplate} class="btn btn-outline-primary btn-sm">
-              Add template
-            </button>
+            </div>
           </div>
-        </div>
-      </div>
+        </>
+      )}
 
       <div class="card mt-2">
         <div class="card-header">

--- a/inventree_bulk_plugin/frontend/src/components/BulkDefinitionSchemaBuilder.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/BulkDefinitionSchemaBuilder.tsx
@@ -104,12 +104,13 @@ export function BulkDefinitionSchemaBuilder({ schema, setSchema, bulkGenerateInf
         <div id={`accordion-${accordionId}-input`} class="collapse">
           <div class="card-body">
             {input.map((inp, i) => (
-              <div class="input-group mb-2">
-                <span class="input-group-text">Key/Value</span>
+              <div class="input-group input-group-sm mb-2">
+                <span class="input-group-text">Key</span>
                 <input type="text" value={inp.key} onInput={setInputKey(i, "key")} />
-                <input type="text" value={inp.value} onInput={setInputKey(i, "value")} />
+                <span class="input-group-text">Value</span>
+                <input type="text" style="flex: 1;" value={inp.value} onInput={setInputKey(i, "value")} />
                 <button class="btn btn-outline-danger btn-sm" onClick={removeInput(i)}>
-                  X
+                  <i class="fa fa-trash"></i>
                 </button>
               </div>
             ))}
@@ -159,8 +160,8 @@ export function BulkDefinitionSchemaBuilder({ schema, setSchema, bulkGenerateInf
                         />
                       </div>
                       <div class="p-1">
-                        <button onClick={removeTemplate(i)} class="btn btn-outline-danger">
-                          X
+                        <button onClick={removeTemplate(i)} class="btn btn-sm btn-outline-danger">
+                          <i class="fa fa-trash"></i>
                         </button>
                       </div>
                     </div>

--- a/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
@@ -19,12 +19,20 @@ const getDefaultValue = (fieldDefinition: FieldDefinition): FieldType => {
 
   if (fieldDefinition.field_type === "list") {
     return [getDefaultValue(fieldDefinition.items_type)];
-  } else if (fieldDefinition.field_type == "object") {
+  } else if (fieldDefinition.field_type === "object") {
     return Object.fromEntries(
       Object.entries(fieldDefinition.fields)
         .filter(([, f]) => f.required)
         .map(([k, f]) => [k, getDefaultValue(f)]),
     );
+  } else if (fieldDefinition.field_type === "boolean") {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    return false;
+  } else if (fieldDefinition.field_type === "float") {
+    return "0";
+  } else if (fieldDefinition.field_type === "number") {
+    return "0";
   }
   return "";
 };

--- a/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
@@ -5,6 +5,9 @@ import { Input } from "./Input";
 import { FieldDefinition, FieldDefinitionList, FieldDefinitionObject, FieldType } from "../utils/types";
 
 const getDefaultValue = (fieldDefinition: FieldDefinition): FieldType => {
+  // use potential default value that is available via API
+  if (fieldDefinition.default) return fieldDefinition.default;
+
   if (fieldDefinition.field_type === "list") {
     return [getDefaultValue(fieldDefinition.items_type)];
   } else if (fieldDefinition.field_type == "object") {

--- a/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
@@ -2,6 +2,7 @@ import { JSX } from "preact";
 import { StateUpdater, useCallback, useMemo, useState } from "preact/hooks";
 
 import { Input } from "./Input";
+import { Tooltip } from "./Tooltip";
 import { FieldDefinition, FieldDefinitionList, FieldDefinitionObject, FieldType } from "../utils/types";
 
 const getDefaultValue = (fieldDefinition: FieldDefinition): FieldType => {
@@ -94,7 +95,11 @@ export const GenerateKeysList = ({ fieldsDefinition, fields, setFields, onDelete
 
   return (
     <div class="mb-2">
-      {fieldsDefinition.name && <h6>{fieldsDefinition.name}</h6>}
+      {fieldsDefinition.name && (
+        <Tooltip text={fieldsDefinition.description || ""}>
+          <h6>{fieldsDefinition.name}</h6>
+        </Tooltip>
+      )}
       <div class="card p-2 ms-3">
         {fields.map((field, i) => (
           <GenerateKeys
@@ -174,7 +179,11 @@ export const GenerateKeysObject = ({
     <div class={`${showCard ? "card mb-1" : ""}`}>
       <div class="d-flex justify-content-between">
         <div class={`col ${showCard ? "p-2" : ""}`} style={{ marginBottom: "-15px" }}>
-          {fieldsDefinition.name && <h6>{fieldsDefinition.name}</h6>}
+          {fieldsDefinition.name && (
+            <Tooltip text={fieldsDefinition.description || ""}>
+              <h6>{fieldsDefinition.name}</h6>
+            </Tooltip>
+          )}
           {Object.entries(subFieldsDefinition)
             .filter(([key]) => fields[key] !== undefined)
             .map(([key, fieldDefinition]) => {

--- a/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
@@ -1,0 +1,216 @@
+import { JSX } from "preact";
+import { StateUpdater, useCallback, useMemo, useState } from "preact/hooks";
+
+import { Input } from "./Input";
+import { FieldDefinition, FieldDefinitionList, FieldDefinitionObject, FieldType } from "../utils/types";
+
+const getDefaultValue = (fieldDefinition: FieldDefinition): FieldType => {
+  if (fieldDefinition.field_type === "list") {
+    return [getDefaultValue(fieldDefinition.items_type)];
+  } else if (fieldDefinition.field_type == "object") {
+    return Object.fromEntries(
+      Object.entries(fieldDefinition.fields)
+        .filter(([, f]) => f.required)
+        .map(([k, f]) => [k, getDefaultValue(f)]),
+    );
+  }
+  return "";
+};
+
+interface GenerateKeysProps {
+  fieldDefinition: FieldDefinition;
+  field: FieldType;
+  setField: StateUpdater<FieldType>;
+  onDelete?: () => void;
+}
+
+export const GenerateKeys = ({ fieldDefinition, field, setField, onDelete }: GenerateKeysProps) => {
+  if (fieldDefinition.field_type === "object") {
+    return (
+      <GenerateKeysObject
+        fieldsDefinition={fieldDefinition}
+        fields={field as Record<string, FieldType>}
+        setFields={setField as StateUpdater<Record<string, FieldType>>}
+        onDelete={onDelete}
+      />
+    );
+  }
+  if (fieldDefinition.field_type === "list") {
+    return (
+      <GenerateKeysList
+        fieldsDefinition={fieldDefinition}
+        fields={field as FieldType[]}
+        setFields={setField as StateUpdater<FieldType[]>}
+        onDelete={onDelete}
+      />
+    );
+  }
+
+  return (
+    <Input
+      label={fieldDefinition.name}
+      tooltip={fieldDefinition.description || undefined}
+      type="text"
+      value={field as string}
+      onInput={(e: JSX.TargetedEvent<HTMLInputElement, Event>) => setField(e.currentTarget.value)}
+      onDelete={onDelete}
+    />
+  );
+};
+
+interface GenerateKeysListProps {
+  fieldsDefinition: FieldDefinitionList;
+  fields: FieldType[];
+  setFields: StateUpdater<FieldType[]>;
+  onDelete?: () => void;
+}
+export const GenerateKeysList = ({ fieldsDefinition, fields, setFields, onDelete }: GenerateKeysListProps) => {
+  const itemsFieldsDefinition = fieldsDefinition.items_type;
+  const setField = useCallback(
+    (i: number) => (value: FieldType | ((prevState: FieldType) => FieldType)) => {
+      setFields((fields) => {
+        const copy = [...fields];
+        copy[i] = typeof value === "function" ? value(copy[i]) : value;
+        return copy;
+      });
+    },
+    [setFields],
+  );
+
+  const handleAddGenerateKey = useCallback(() => {
+    const defaultValue = getDefaultValue(itemsFieldsDefinition);
+    setFields((f) => [...f, defaultValue]);
+  }, [itemsFieldsDefinition, setFields]);
+
+  const handleDeleteGenerateKey = useCallback(
+    (i: number) => () => {
+      setFields((fields) => fields.filter((_f, ii) => i !== ii));
+    },
+    [setFields],
+  );
+
+  return (
+    <div class="mb-2">
+      {fieldsDefinition.name && <h6>{fieldsDefinition.name}</h6>}
+      <div class="card p-2 ms-3">
+        {fields.map((field, i) => (
+          <GenerateKeys
+            fieldDefinition={itemsFieldsDefinition}
+            field={field}
+            setField={setField(i)}
+            onDelete={handleDeleteGenerateKey(i)}
+          />
+        ))}
+        <div style={{ display: "flex", justifyContent: "space-between" }}>
+          <button class="btn btn-small btn-outline-primary" onClick={handleAddGenerateKey}>
+            Add {fieldsDefinition.name}
+          </button>
+          {onDelete && (
+            <button class="btn btn-small btn-outline-danger pe-2 ps-2" onClick={onDelete}>
+              X
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+interface GenerateKeysObjectProps {
+  fieldsDefinition: FieldDefinitionObject;
+  fields: Record<string, FieldType>;
+  setFields: StateUpdater<Record<string, FieldType>>;
+  onDelete?: () => void;
+  showCard?: boolean;
+}
+export const GenerateKeysObject = ({
+  fieldsDefinition,
+  fields,
+  setFields,
+  onDelete,
+  showCard = true,
+}: GenerateKeysObjectProps) => {
+  const subFieldsDefinition = fieldsDefinition.fields;
+  const setGenerateValue = useCallback(
+    (key: string) => (value: FieldType | ((prevState: FieldType) => FieldType)) =>
+      setFields((f) => ({ ...f, [key]: typeof value === "function" ? value(f[key]) : value })),
+    [setFields],
+  );
+
+  const remainingGenerateKeys = useMemo(() => {
+    const currentKeys = Object.keys(fields);
+    return Object.entries(subFieldsDefinition).filter(([k]) => !currentKeys.includes(k));
+  }, [fields, subFieldsDefinition]);
+
+  const [remainingGenerateKeysValue, setRemainingGenerateKeysValue] = useState("");
+
+  const handleAddGenerateKey = useCallback(
+    (key: string) => {
+      if (key !== "") {
+        const field = subFieldsDefinition[key];
+        const defaultValue = getDefaultValue(field);
+        setGenerateValue(key)(defaultValue);
+        setRemainingGenerateKeysValue("");
+      }
+    },
+    [subFieldsDefinition, setGenerateValue],
+  );
+
+  const handleDeleteGenerateKey = useCallback(
+    (key: string) => () => {
+      setFields((f) => {
+        const copy = { ...f };
+        delete copy[key];
+        return copy;
+      });
+    },
+    [setFields],
+  );
+
+  return (
+    <div class={`${showCard ? "card mb-1" : ""}`}>
+      <div class="d-flex justify-content-between">
+        <div class={`col ${showCard ? "p-2" : ""}`} style={{ marginBottom: "-15px" }}>
+          {fieldsDefinition.name && <h6>{fieldsDefinition.name}</h6>}
+          {Object.entries(subFieldsDefinition)
+            .filter(([key]) => fields[key] !== undefined)
+            .map(([key, fieldDefinition]) => {
+              const value = fields[key];
+
+              return (
+                <GenerateKeys
+                  fieldDefinition={fieldDefinition}
+                  field={value}
+                  setField={setGenerateValue(key)}
+                  onDelete={fieldDefinition.required ? undefined : handleDeleteGenerateKey(key)}
+                />
+              );
+            })}
+          {remainingGenerateKeys.length > 0 && (
+            <div style="display: flex; max-width: 200px; margin-bottom: 15px;">
+              <select
+                class="form-select form-select-sm"
+                value={remainingGenerateKeysValue}
+                onInput={(e) => handleAddGenerateKey(e.currentTarget.value)}
+              >
+                <option selected value="">
+                  Add key
+                </option>
+                {remainingGenerateKeys.map(([key, { name }]) => (
+                  <option value={key}>{name}</option>
+                ))}
+              </select>
+            </div>
+          )}
+        </div>
+        {onDelete && (
+          <div class="p-1">
+            <button onClick={onDelete} class="btn btn-outline-danger">
+              X
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
@@ -254,6 +254,18 @@ const getTemplateHelpTexts = (fieldDefinition: FieldDefinition): string => {
   return "";
 };
 
+const detectUseTemplate = (
+  fieldDefinition: FieldDefinitionText | FieldDefinitionModel | FieldDefinitionSelect,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value: any,
+) => {
+  const valueStr = `${value}`;
+  if (fieldDefinition.field_type === "number") return !/^\d*$/.test(valueStr);
+  if (fieldDefinition.field_type === "float") return !/^[\d\\.,]*$/.test(valueStr);
+  if (fieldDefinition.field_type === "boolean") return !(valueStr in ["true", "false"]);
+  return valueStr.includes("{") || valueStr.includes("}");
+};
+
 interface GenerateKeysSingleProps {
   fieldDefinition: FieldDefinitionText | FieldDefinitionModel | FieldDefinitionSelect;
   field: FieldType;
@@ -261,7 +273,7 @@ interface GenerateKeysSingleProps {
   onDelete?: () => void;
 }
 const GenerateKeysSingle = ({ fieldDefinition, field, setField, onDelete }: GenerateKeysSingleProps) => {
-  const [useTemplate, setTemplate] = useState(false);
+  const [useTemplate, setTemplate] = useState(() => detectUseTemplate(fieldDefinition, field));
   const showUseTemplate = useMemo(() => fieldDefinition.field_type !== "text", [fieldDefinition.field_type]);
   const id = useId();
 

--- a/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
@@ -196,6 +196,7 @@ export const GenerateKeysObject = ({
 
               return (
                 <GenerateKeys
+                  key={key}
                   fieldDefinition={fieldDefinition}
                   field={value}
                   setField={setGenerateValue(key)}
@@ -262,7 +263,7 @@ const detectUseTemplate = (
   const valueStr = `${value}`;
   if (fieldDefinition.field_type === "number") return !/^\d*$/.test(valueStr);
   if (fieldDefinition.field_type === "float") return !/^[\d\\.,]*$/.test(valueStr);
-  if (fieldDefinition.field_type === "boolean") return !(valueStr in ["true", "false"]);
+  if (fieldDefinition.field_type === "boolean") return !["true", "false", ""].includes(valueStr);
   return valueStr.includes("{") || valueStr.includes("}");
 };
 
@@ -273,7 +274,7 @@ interface GenerateKeysSingleProps {
   onDelete?: () => void;
 }
 const GenerateKeysSingle = ({ fieldDefinition, field, setField, onDelete }: GenerateKeysSingleProps) => {
-  const [useTemplate, setTemplate] = useState(() => detectUseTemplate(fieldDefinition, field));
+  const [useTemplate, setUseTemplate] = useState(() => detectUseTemplate(fieldDefinition, field));
   const showUseTemplate = useMemo(() => fieldDefinition.field_type !== "text", [fieldDefinition.field_type]);
   const id = useId();
 
@@ -305,7 +306,7 @@ const GenerateKeysSingle = ({ fieldDefinition, field, setField, onDelete }: Gene
                 class="btn-check"
                 id={`btn-check-${id}`}
                 checked={useTemplate}
-                onInput={() => setTemplate((v) => !v)}
+                onInput={() => setUseTemplate((v) => !v)}
                 autoComplete={"off"}
               />
               {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}

--- a/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
@@ -8,6 +8,7 @@ import {
   FieldDefinitionList,
   FieldDefinitionModel,
   FieldDefinitionObject,
+  FieldDefinitionSelect,
   FieldDefinitionText,
   FieldType,
 } from "../utils/types";
@@ -231,15 +232,30 @@ export const GenerateKeysObject = ({
   );
 };
 
-const templateHelpTexts: Record<string, string> = {
-  boolean: "Use a template that evaluates to something boolean like (e.g. 'true' or 'false').",
-  number: "Use a template that evaluates to something number like (e.g. '10').",
-  float: "Use a template that evaluates to something float like (e.g. '3.1415').",
-  model: "Use a template that evaluates to a valid id for this model (e.g. '42').",
+const getTemplateHelpTexts = (fieldDefinition: FieldDefinition): string => {
+  if (fieldDefinition.field_type === "boolean") {
+    return "Use a template that evaluates to something boolean like (e.g. 'true' or 'false').";
+  }
+  if (fieldDefinition.field_type === "number") {
+    return "Use a template that evaluates to something number like (e.g. '10').";
+  }
+  if (fieldDefinition.field_type === "float") {
+    return "Use a template that evaluates to something float like (e.g. '3.1415').";
+  }
+  if (fieldDefinition.field_type === "model") {
+    return "Use a template that evaluates to a valid id for this model (e.g. '42').";
+  }
+  if (fieldDefinition.field_type === "select") {
+    return `Use a template that evaluates to a valid option from the select field. Available options: ${Object.keys(
+      fieldDefinition.options,
+    ).join(", ")}`;
+  }
+
+  return "";
 };
 
 interface GenerateKeysSingleProps {
-  fieldDefinition: FieldDefinitionText | FieldDefinitionModel;
+  fieldDefinition: FieldDefinitionText | FieldDefinitionModel | FieldDefinitionSelect;
   field: FieldType;
   setField: StateUpdater<FieldType>;
   onDelete?: () => void;
@@ -264,6 +280,7 @@ const GenerateKeysSingle = ({ fieldDefinition, field, setField, onDelete }: Gene
         tooltip={fieldDefinition.description || undefined}
         type={fieldType}
         {...(fieldDefinition.field_type === "model" ? { model: fieldDefinition.model } : {})}
+        {...(fieldDefinition.field_type === "select" ? { options: fieldDefinition.options } : {})}
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         value={field as any}
         onInput={(e: JSX.TargetedEvent<HTMLInputElement, Event>) => setField(e.currentTarget.value)}
@@ -285,7 +302,7 @@ const GenerateKeysSingle = ({ fieldDefinition, field, setField, onDelete }: Gene
                 for={`btn-check-${id}`}
                 style="display: flex; align-items: center;"
               >
-                <Tooltip text={templateHelpTexts[fieldDefinition.field_type]}>
+                <Tooltip text={getTemplateHelpTexts(fieldDefinition)}>
                   <i class="fas fa-code"></i>
                 </Tooltip>
               </label>

--- a/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
@@ -178,7 +178,7 @@ export const GenerateKeysObject = ({
   return (
     <div class={`${showCard ? "card mb-1" : ""}`}>
       <div class="d-flex justify-content-between">
-        <div class={`col ${showCard ? "p-2" : ""}`} style={{ marginBottom: "-15px" }}>
+        <div class={`col ${showCard ? "p-2" : ""}`}>
           {fieldsDefinition.name && (
             <Tooltip text={fieldsDefinition.description || ""}>
               <h6>{fieldsDefinition.name}</h6>
@@ -199,7 +199,7 @@ export const GenerateKeysObject = ({
               );
             })}
           {remainingGenerateKeys.length > 0 && (
-            <div style="display: flex; max-width: 200px; margin-bottom: 15px;">
+            <div style="display: flex; max-width: 200px;">
               <select
                 class="form-select form-select-sm"
                 value={remainingGenerateKeysValue}

--- a/inventree_bulk_plugin/frontend/src/components/Input.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/Input.tsx
@@ -1,25 +1,31 @@
-import { useId } from "preact/hooks";
+import { ComponentChildren, JSX } from "preact";
+import { useEffect, useId } from "preact/hooks";
 
 import { Tooltip } from "./Tooltip";
 
 interface DefaultInputProps {
   label: string;
   tooltip?: string;
+  extraButtons?: ComponentChildren;
+  onDelete?: () => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
 interface TextInputProps extends DefaultInputProps {
-  type: "text" | "email" | "number";
+  type: "text" | "email" | "number" | "float";
   value: string;
-  onDelete?: () => void;
+}
+interface ModelInputProps extends DefaultInputProps {
+  type: "model";
+  value: string;
+  model: { model: string; limit_choices_to: Record<string, string>; api_url: string };
 }
 interface NumberInputProps extends DefaultInputProps {
   type: "number";
   value: number;
-  onDelete?: () => void;
 }
 interface CheckboxInputProps extends DefaultInputProps {
-  type: "checkbox";
+  type: "checkbox" | "boolean";
   value: boolean;
 }
 interface SelectInputProps extends DefaultInputProps {
@@ -27,16 +33,33 @@ interface SelectInputProps extends DefaultInputProps {
   value: string;
   options: Record<string, string>;
 }
-interface ArrayInputProps extends DefaultInputProps {
+interface ArrayInputProps extends Omit<DefaultInputProps, "onDelete"> {
   type: "array";
   value: string[];
   onDelete?: (i: number) => () => void;
   onAdd?: () => void;
 }
-type InputProps = TextInputProps | NumberInputProps | CheckboxInputProps | SelectInputProps | ArrayInputProps;
+type InputProps =
+  | TextInputProps
+  | ModelInputProps
+  | NumberInputProps
+  | CheckboxInputProps
+  | SelectInputProps
+  | ArrayInputProps;
 
 export function Input(props: InputProps) {
   const id = useId();
+
+  const extraFormGroup = (
+    <>
+      {props.extraButtons}
+      {props.onDelete && (
+        <button class="btn btn-outline-danger btn-sm" onClick={props.onDelete as () => void}>
+          <i class="fa fa-trash"></i>
+        </button>
+      )}
+    </>
+  );
 
   return (
     <div class="form-group row">
@@ -48,39 +71,51 @@ export function Input(props: InputProps) {
         </Tooltip>
       </div>
       {(() => {
-        if (props.type === "text" || props.type === "number" || props.type === "email") {
+        if (props.type === "text" || props.type === "number" || props.type === "email" || props.type === "float") {
           const { type, ...inputProps } = props;
           return (
             <div class="col-sm-10 input-group" style="flex: 1;">
-              <input type={type} class="form-control form-control-sm" id={`input-${id}`} {...inputProps} />
-              {props.onDelete && (
-                <button class="btn btn-outline-danger btn-sm" onClick={props.onDelete}>
-                  X
-                </button>
-              )}
-            </div>
-          );
-        } else if (props.type === "checkbox") {
-          const { type, value, ...inputProps } = props;
-          return (
-            <div class="col-sm-10">
               <input
-                type={type}
-                class="form-check-input form-check-sm"
+                type={type === "float" ? "number" : type}
+                class="form-control form-control-sm"
                 id={`input-${id}`}
-                checked={value}
+                {...(type === "float" ? { step: "any" } : {})}
                 {...inputProps}
               />
+              {extraFormGroup}
+            </div>
+          );
+        } else if (props.type === "model") {
+          return <ModelInput extraFormGroup={extraFormGroup} id={id} {...props} />;
+        } else if (props.type === "checkbox" || props.type === "boolean") {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { type, value, ...inputProps } = props;
+          return (
+            <div class="col-sm-10 input-group" style="flex: 1;">
+              <label class="input-group-text" style="flex: 1;" for={`input-${id}`}>
+                <input
+                  type="checkbox"
+                  class="form-check-input form-check-sm"
+                  id={`input-${id}`}
+                  checked={value}
+                  {...inputProps}
+                  onInput={(e: JSX.TargetedEvent<HTMLInputElement, Event>) =>
+                    inputProps.onInput?.({ currentTarget: { value: e.currentTarget.checked } })
+                  }
+                />
+              </label>
+              {extraFormGroup}
             </div>
           );
         } else if (props.type === "select") {
           return (
-            <div class="col-sm-10">
+            <div class="col-sm-10 input-group">
               <select class="form-select form-select-sm" id={`input-${id}`} {...props}>
                 {Object.entries(props.options).map(([k, v]) => (
                   <option value={k}>{v}</option>
                 ))}
               </select>
+              {extraFormGroup}
             </div>
           );
         } else if (props.type === "array") {
@@ -101,7 +136,7 @@ export function Input(props: InputProps) {
                     />
                     {onDelete && (
                       <button class="btn btn-outline-danger btn-sm" onClick={onDelete(i)}>
-                        X
+                        <i class="fa fa-trash"></i>
                       </button>
                     )}
                   </div>
@@ -121,3 +156,137 @@ export function Input(props: InputProps) {
     </div>
   );
 }
+
+interface ModelInputComponentProps extends ModelInputProps {
+  extraFormGroup: ComponentChildren;
+  id: string;
+}
+
+const ModelInput = ({ model, extraFormGroup, id, onInput, value }: ModelInputComponentProps) => {
+  /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/ban-ts-comment */
+  useEffect(() => {
+    // @ts-ignore
+    $(`#${id}`).select2({
+      placeholder: "",
+      allowClear: true,
+      ajax: {
+        url: model.api_url,
+        dataType: "json",
+        delay: 250,
+        cache: true,
+        data: (params: any) => {
+          return {
+            search: params.term?.trim(),
+            offset: params.page ? (params.page - 1) * 25 : 0,
+            limit: 25,
+            ...model.limit_choices_to,
+          };
+        },
+        processResults: (response: any) => {
+          let data = [];
+          let more = false;
+
+          if ("count" in response && "results" in response) {
+            // Response is paginated
+            data = response.results;
+
+            if (response.next) more = true;
+          } else {
+            // Non-paginated response
+            data = response;
+          }
+
+          return {
+            results: data.map((x: any) => ({ id: x.pk, ...x })),
+            pagination: {
+              more,
+            },
+          };
+        },
+      },
+      templateResult: (item: any) => {
+        let data = item;
+        if (item.element?.instance) {
+          data = item.element.instance;
+        }
+
+        if (!data.pk) {
+          return $(`<span>Searching...</span>`);
+        }
+        const modelName = model.model.toLowerCase().split(".").at(-1);
+
+        // @ts-ignore
+        return $(`${renderModelData("", modelName, data, {})} <span>(${data.pk})</span>`);
+      },
+      templateSelection: (item: any) => {
+        let data = item;
+        if (item.element?.instance) {
+          data = item.element.instance;
+        }
+
+        if (!data.pk) {
+          return "";
+        }
+        const modelName = model.model.toLowerCase().split(".").at(-1);
+
+        // @ts-ignore
+        return $(`${renderModelData("", modelName, data, {})} <span>(${data.pk})</span>`);
+      },
+    });
+
+    return () => {
+      //@ts-ignore
+      $(`#${id}`).select2("destroy");
+    };
+  }, [id, model.api_url, model.limit_choices_to, model.model]);
+
+  useEffect(() => {
+    $(`#${id}`).on("select2:select", (e) => {
+      onInput?.(e);
+    });
+    $(`#${id}`).on("select2:clear", () => {
+      onInput?.({ currentTarget: { value: "" } });
+    });
+
+    return () => {
+      $(`#${id}`).off("select2:select");
+      $(`#${id}`).off("select2:clear");
+    };
+  }, [id, onInput]);
+
+  useEffect(() => {
+    if (value && value !== $(`#${id}`).val()) {
+      // current selected value and value from state are different
+      const url = `${model.api_url}/${value}/`.replace("//", "/");
+
+      // @ts-ignore
+      inventreeGet(
+        url,
+        { ...model.limit_choices_to },
+        {
+          success: (data: any) => {
+            const option = new Option("", data.pk, true, true);
+            // @ts-ignore
+            option.instance = data;
+            $(`#${id}`).append(option).trigger("change");
+            $(`#${id}`).trigger({
+              type: "select2:select",
+              // @ts-ignore
+              params: {
+                data,
+              },
+            });
+          },
+        },
+      );
+    }
+  }, [id, model.api_url, model.limit_choices_to, value]);
+  /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/ban-ts-comment */
+
+  return (
+    <div class="col-sm-10 input-group" style="flex: 1;">
+      <select class="form-select form-select-sm" id={id}></select>
+      {extraFormGroup}
+    </div>
+  );
+};

--- a/inventree_bulk_plugin/frontend/src/components/Input.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/Input.tsx
@@ -109,7 +109,7 @@ export function Input(props: InputProps) {
           );
         } else if (props.type === "select") {
           return (
-            <div class="col-sm-10 input-group">
+            <div class="col-sm-10 input-group" style="flex: 1;">
               <select class="form-select form-select-sm" id={`input-${id}`} {...props}>
                 {Object.entries(props.options).map(([k, v]) => (
                   <option value={k}>{v}</option>

--- a/inventree_bulk_plugin/frontend/src/components/PreviewCreate.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/PreviewCreate.tsx
@@ -113,7 +113,7 @@ export const PreviewCreate = ({
         <>
           <h5>Preview</h5>
           <div class={initial ? "mb-4" : ""}>
-            <PreviewTable template={previewTemplate} height={250} parentId={parentId} />
+            <PreviewTable template={previewTemplate} height={350} parentId={parentId} />
           </div>
         </>
       )}

--- a/inventree_bulk_plugin/frontend/src/components/PreviewCreate.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/PreviewCreate.tsx
@@ -3,6 +3,7 @@ import { StateUpdater, useCallback, useEffect, useState } from "preact/hooks";
 
 import { Input } from "./Input";
 import { PreviewTable } from "./PreviewTable";
+import { useBulkGenerateInfo } from "../contexts/BulkCreateInfo";
 import { useNotifications } from "../contexts/Notification";
 import { beautifySchema } from "../utils";
 import { URLS, fetchAPI } from "../utils/api";
@@ -42,9 +43,10 @@ export const PreviewCreate = ({
 }: PreviewCreateProps) => {
   const [previewTemplate, setPreviewTemplate] = useState<TemplateModel>();
   const [inputs, setInputs] = useState<InputType[]>([]);
-  const [initial, setIntial] = useState(true);
+  const [initial, setInitial] = useState(true);
 
   const { showNotification } = useNotifications();
+  const { bulkGenerateInfoDict } = useBulkGenerateInfo();
 
   useEffect(() => {
     setInputs(Object.entries(template.template.input).map(([k, v]) => ({ key: k, value: v })));
@@ -75,17 +77,20 @@ export const PreviewCreate = ({
 
     if (!res.ok) {
       handleDoneCreate?.(false);
-      return showNotification({ type: "danger", message: `An error occourd, ${json.error}` });
+      return showNotification({ type: "danger", message: `An error occurred, ${json.error}` });
     }
 
-    showNotification({ type: "success", message: `Successfully bulk created ${json.length} ${final.template_type}s.` });
+    showNotification({
+      type: "success",
+      message: `Successfully bulk created ${json.length} ${bulkGenerateInfoDict[final.template_type]?.name}s.`,
+    });
     handleDoneCreate?.(true);
-  }, [handleDoneCreate, inputs, parentId, setIsBulkCreateLoading, showNotification, template]);
+  }, [bulkGenerateInfoDict, handleDoneCreate, inputs, parentId, setIsBulkCreateLoading, showNotification, template]);
 
   const previewHandler = useCallback(() => {
     const final = structuredClone(getTemplateWithInputs(template, inputs));
     setPreviewTemplate(final);
-    setIntial(false);
+    setInitial(false);
   }, [inputs, template]);
 
   const createHandler = useCallback(() => {

--- a/inventree_bulk_plugin/frontend/src/components/PreviewTable.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/PreviewTable.tsx
@@ -2,9 +2,10 @@ import { useEffect, useId, useMemo } from "preact/hooks";
 
 import { useBulkGenerateInfo } from "../contexts/BulkCreateInfo";
 import { useNotifications } from "../contexts/Notification";
-import { beautifySchema, getCounter, getUsedGenerateKeys, toFlat } from "../utils";
+import { beautifySchema, escapeHtml, getCounter, getUsedGenerateKeys, toFlat } from "../utils";
 import { URLS, fetchAPI } from "../utils/api";
-import { TemplateModel } from "../utils/types";
+import { customModelProcessors } from "../utils/customModelProcessors";
+import { FieldDefinition, FieldType, TemplateModel } from "../utils/types";
 
 interface PreviewTableProps {
   template: TemplateModel;
@@ -42,6 +43,84 @@ export const PreviewTable = ({ template, height, parentId }: PreviewTableProps) 
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const $table = $(`#${tableId}`) as any;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const cache: Record<string, ((field: any) => void)[]> = {};
+
+      const format = (fieldDefinition: FieldDefinition, value: FieldType, cellId: string): string => {
+        if (fieldDefinition.field_type === "model") {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const handleSuccess = (field: any) => {
+            const fetchedValue = (() => {
+              if (customModelProcessors[fieldDefinition.model.model]) {
+                field = customModelProcessors[fieldDefinition.model.model].mapFunction(field);
+              }
+              if (field.element?.instance) {
+                field = field.element.instance;
+              }
+
+              if (customModelProcessors[fieldDefinition.model.model]) {
+                return customModelProcessors[fieldDefinition.model.model].render(field);
+              }
+
+              if (!field.pk) {
+                return "";
+              }
+              const modelName = fieldDefinition.model.model.toLowerCase().split(".").at(-1);
+
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              return `${renderModelData("", modelName, field, {})} <span>(${field.pk})</span>`;
+            })();
+
+            const cell = document.getElementById(cellId);
+            if (cell) {
+              cell.innerHTML = fetchedValue;
+              cell.classList.remove("placeholder", "placeholder-glow", "col-4");
+            }
+          };
+
+          const customProcessor = customModelProcessors[fieldDefinition.model.model];
+          if (customProcessor?.getSingle) {
+            const cacheKey = `~get-single-${value}`;
+            if (!cache[cacheKey]) {
+              cache[cacheKey] = [];
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              customProcessor.getSingle(value, (d: any) => cache[cacheKey].forEach((handler) => handler(d)));
+            }
+            cache[cacheKey].push(handleSuccess);
+          } else {
+            const url = `${fieldDefinition.model.api_url}/${value}/`.replace("//", "/");
+
+            if (!cache[url]) {
+              cache[url] = [];
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              inventreeGet(
+                url,
+                { ...fieldDefinition.model.limit_choices_to },
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                { success: (d: any) => cache[url].forEach((handler) => handler(d)) },
+              );
+            }
+            cache[url].push(handleSuccess);
+          }
+
+          return `<span id=${cellId} class="placeholder placeholder-glow col-4">${value}</span>`;
+        }
+        if (fieldDefinition.field_type === "list" && Array.isArray(value)) {
+          return `<ul>${value
+            .map((r, i) => `<li>${format(fieldDefinition.items_type, r, `${cellId}-${i}`)}</li>`)
+            .join("")}</ul>`;
+        }
+        if (fieldDefinition.field_type === "object" && typeof value === "object") {
+          return `<ul>${Object.entries(value)
+            .map(([k, r], i) => `<li>${escapeHtml(k)}: ${format(fieldDefinition.fields[k], r, `${cellId}-${i}`)}</li>`)
+            .join("")}</ul>`;
+        }
+        return escapeHtml(`${value}`);
+      };
+
       $table.bootstrapTable("destroy");
       $table.bootstrapTable({
         data,
@@ -50,7 +129,12 @@ export const PreviewTable = ({ template, height, parentId }: PreviewTableProps) 
         columns: [
           ...Object.entries(bulkGenerateInfoDict[template.template_type].fields)
             .filter(([key]) => usedGenerateKeys.includes(key))
-            .map(([key, { name }]) => ({ field: key, title: name })),
+            .map(([key, f]) => ({
+              field: key,
+              title: f.name,
+              formatter: (value: FieldType, _row: Record<string, FieldType>, index: number) =>
+                format(f, value, `table-${id}-field-${index}`),
+            })),
           { field: "path", title: "Path" },
         ],
         treeShowField: "name",
@@ -74,7 +158,7 @@ export const PreviewTable = ({ template, height, parentId }: PreviewTableProps) 
         }),
       });
     })();
-  }, [bulkGenerateInfoDict, height, parentId, showNotification, tableId, template]);
+  }, [bulkGenerateInfoDict, height, id, parentId, showNotification, tableId, template]);
 
   return (
     <div class="mt-3">

--- a/inventree_bulk_plugin/frontend/src/components/PreviewTable.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/PreviewTable.tsx
@@ -32,7 +32,7 @@ export const PreviewTable = ({ template, height, parentId }: PreviewTableProps) 
       const json = await res.json();
 
       if (!res.ok) {
-        return showNotification({ type: "danger", message: `An error occourd, ${json.error}` });
+        return showNotification({ type: "danger", message: `An error occurred, ${json.error}` });
       }
 
       const data = toFlat(json, getCounter());
@@ -48,6 +48,8 @@ export const PreviewTable = ({ template, height, parentId }: PreviewTableProps) 
       const cache: Record<string, ((field: any) => void)[]> = {};
 
       const format = (fieldDefinition: FieldDefinition, value: FieldType, cellId: string): string => {
+        if (value === undefined) return "";
+
         if (fieldDefinition.field_type === "model") {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const handleSuccess = (field: any) => {

--- a/inventree_bulk_plugin/frontend/src/components/PreviewTable.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/PreviewTable.tsx
@@ -77,6 +77,7 @@ export const PreviewTable = ({ template, height, parentId }: PreviewTableProps) 
             if (cell) {
               cell.innerHTML = fetchedValue;
               cell.classList.remove("placeholder", "placeholder-glow", "col-4");
+              $table.bootstrapTable("resetView");
             }
           };
 
@@ -162,7 +163,7 @@ export const PreviewTable = ({ template, height, parentId }: PreviewTableProps) 
 
   return (
     <div class="mt-3">
-      <table id={tableId}></table>
+      <table id={tableId} style={{ whiteSpace: "nowrap" }}></table>
     </div>
   );
 };

--- a/inventree_bulk_plugin/frontend/src/components/TemplateForm.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/TemplateForm.tsx
@@ -146,9 +146,9 @@ export const TemplateForm = ({ templateId, handleBack, templateType, parentId }:
 
     showNotification({
       type: "success",
-      message: `Successfully bulk created ${json.length} ${template.template_type}s.`,
+      message: `Successfully bulk created ${json.length} ${bulkGenerateInfoDict[template.template_type]?.name}s.`,
     });
-  }, [parentId, showNotification, template]);
+  }, [bulkGenerateInfoDict, parentId, showNotification, template]);
 
   return (
     <div>
@@ -237,7 +237,8 @@ export const TemplateForm = ({ templateId, handleBack, templateType, parentId }:
           },
         ]}
       >
-        Are you sure you want to bulk generate sub-{template?.template_type}s here?
+        Are you sure you want to bulk generate{" "}
+        {bulkGenerateInfoDict[template?.template_type || ""]?.name || template?.template_type}s here?
       </Dialog>
     </div>
   );

--- a/inventree_bulk_plugin/frontend/src/components/TemplateForm.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/TemplateForm.tsx
@@ -184,7 +184,7 @@ export const TemplateForm = ({ templateId, handleBack, templateType, parentId }:
         </div>
       )}
 
-      {!isLoading && !isBulkGenerateInfoLoading && template && (
+      {!isLoading && !isBulkGenerateInfoLoading && bulkGenerateInfo && template && (
         <div>
           <Input label="Name" type="text" value={template.name} onInput={updateField("name")} />
           {!templateType && (
@@ -200,7 +200,7 @@ export const TemplateForm = ({ templateId, handleBack, templateType, parentId }:
           <BulkDefinitionSchemaBuilder
             schema={template.template}
             setSchema={updateTemplate}
-            bulkGenerateInfo={bulkGenerateInfo || bulkGenerateInfoDict[template.template_type]}
+            bulkGenerateInfo={bulkGenerateInfo}
           />
         </div>
       )}
@@ -239,7 +239,9 @@ export const TemplateForm = ({ templateId, handleBack, templateType, parentId }:
         )}
       </div>
 
-      {previewTemplate && <PreviewTable template={previewTemplate} parentId={parentId} />}
+      {previewTemplate && bulkGenerateInfo && (
+        <PreviewTable template={previewTemplate} parentId={parentId} bulkGenerateInfo={bulkGenerateInfo} />
+      )}
 
       <Dialog
         title="Bulk create"

--- a/inventree_bulk_plugin/frontend/src/components/Tooltip.css
+++ b/inventree_bulk_plugin/frontend/src/components/Tooltip.css
@@ -1,27 +1,4 @@
-/* Tooltips - (Prefixed so the classes doesn't interfer with bootstraps classes) */
 .preact-tooltip {
   position: relative;
   display: inline-block;
-}
-
-.preact-tooltip .preact-tooltiptext {
-  visibility: hidden;
-  width: 350px;
-  background-color: black;
-  color: #fff;
-  border-radius: 6px;
-  padding: 5px;
-  opacity: 0;
-  transition: 50ms all;
-
-  /* Position the tooltip */
-  position: absolute;
-  z-index: 1000;
-  top: -5px;
-  left: 105%;
-}
-
-.preact-tooltip:hover .preact-tooltiptext {
-  visibility: visible;
-  opacity: 1;
 }

--- a/inventree_bulk_plugin/frontend/src/components/Tooltip.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/Tooltip.tsx
@@ -1,21 +1,36 @@
 import { ComponentChildren } from "preact";
+import { useEffect, useId } from "preact/hooks";
 
 import "./Tooltip.css";
 
 interface TooltipProps {
   text?: string;
+  placement?: "right" | "left" | "bottom" | "top" | "auto";
   children: ComponentChildren;
 }
 
-export function Tooltip({ text, children }: TooltipProps) {
+export function Tooltip({ text, children, placement = "auto" }: TooltipProps) {
+  const id = useId();
+
+  useEffect(() => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const tooltip = bootstrap.Tooltip.getOrCreateInstance(el, { placement });
+
+    return () => {
+      tooltip.dispose();
+    };
+  }, [id, placement]);
+
   if (!text) {
     return <>{children}</>;
   }
 
   return (
-    <div class="preact-tooltip">
+    <div id={id} class="preact-tooltip" data-bs-title={text} data-bs-toggle="tooltip">
       {children}
-      <span class="preact-tooltiptext">{text}</span>
     </div>
   );
 }

--- a/inventree_bulk_plugin/frontend/src/utils/api.ts
+++ b/inventree_bulk_plugin/frontend/src/utils/api.ts
@@ -9,10 +9,15 @@ export const fetchAPI = (input: RequestInfo | URL, init?: RequestInit) => {
 };
 
 export const URLS = {
-  bulkcreate: ({ parentId, create }: { parentId?: string; create?: boolean } = {}) => {
+  bulkcreate: ({
+    parentId,
+    create,
+    templateType,
+  }: { parentId?: string; create?: boolean; templateType?: string } = {}) => {
     const params = new URLSearchParams();
     if (parentId) params.set("parent_id", parentId);
     if (create) params.set("create", create ? "true" : "false");
+    if (templateType) params.set("template_type", templateType);
     const paramsString = params.toString();
 
     return `/plugin/inventree-bulk-plugin/bulkcreate${paramsString ? `?${paramsString}` : ""}`;

--- a/inventree_bulk_plugin/frontend/src/utils/customModelProcessors.tsx
+++ b/inventree_bulk_plugin/frontend/src/utils/customModelProcessors.tsx
@@ -1,0 +1,35 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/ban-ts-comment */
+
+// define custom processors for models that does not really exist or have no model renderer
+interface CustomModelProcessor {
+  render: (item: any) => string;
+  mapFunction: (item: any) => any;
+  getSingle?: (id: any, success: (data: any) => void) => void;
+}
+export const customModelProcessors: Record<string, CustomModelProcessor> = {
+  "_part.part_image": {
+    // @ts-ignore
+    render: (item) => {
+      if (!item.pk && !item.id) return "";
+      // @ts-ignore
+      return renderModel({
+        // @ts-ignore
+        image: item.image ? `/media/${item.image}` : blankImage(),
+        text: item.image || `Not found: ${item.id}`,
+      });
+    },
+    mapFunction: (item) => ({ ...item, id: item.image || item.id }),
+    getSingle: (id, success) => {
+      // @ts-ignore
+      inventreeGet(
+        `/api/part/thumbs/`,
+        {},
+        {
+          success: (data: any) => {
+            success(data.find((x: any) => x.image === id) || { image: "", id });
+          },
+        },
+      );
+    },
+  },
+};

--- a/inventree_bulk_plugin/frontend/src/utils/customModelProcessors.tsx
+++ b/inventree_bulk_plugin/frontend/src/utils/customModelProcessors.tsx
@@ -11,10 +11,20 @@ export const customModelProcessors: Record<string, CustomModelProcessor> = {
     // @ts-ignore
     render: (item) => {
       if (!item.pk && !item.id) return "";
+      if (!item.image) item.image = item.pk || item.id;
+      let imageUrl = "";
+
+      if (item.image) {
+        // check if absolute url, then use it directly
+        imageUrl = /^(?:[a-z+]+:)?\/\//.test(item.image) ? item.image : `/media/${item.image}`;
+      } else {
+        // @ts-ignore
+        imageUrl = blankImage();
+      }
+
       // @ts-ignore
       return renderModel({
-        // @ts-ignore
-        image: item.image ? `/media/${item.image}` : blankImage(),
+        image: imageUrl,
         text: item.image || `Not found: ${item.id}`,
       });
     },

--- a/inventree_bulk_plugin/frontend/src/utils/index.ts
+++ b/inventree_bulk_plugin/frontend/src/utils/index.ts
@@ -84,3 +84,11 @@ export const toFlat = (data: BulkGenerateAPIResult, counter: () => number, pid =
     const path = `${pa}/${parent.name}`;
     return [{ ...parent, id, pid, path }, ...toFlat(childs, counter, id, path)];
   });
+
+export const escapeHtml = (unsafe: string) =>
+  unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");

--- a/inventree_bulk_plugin/frontend/src/utils/types.ts
+++ b/inventree_bulk_plugin/frontend/src/utils/types.ts
@@ -2,13 +2,17 @@ export interface FieldDefinitionBase {
   name: string;
   description: null | string;
   required: boolean;
-  model: null | { model: string; limit_choices_to: Record<string, string> };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   default?: any;
 }
 
 export interface FieldDefinitionText extends FieldDefinitionBase {
-  field_type: "text" | "boolean" | "number" | "model";
+  field_type: "text" | "boolean" | "number" | "float";
+}
+
+export interface FieldDefinitionModel extends FieldDefinitionBase {
+  field_type: "model";
+  model: { model: string; limit_choices_to: Record<string, string>; api_url: string };
 }
 
 export interface FieldDefinitionObject extends FieldDefinitionBase {
@@ -21,7 +25,7 @@ export interface FieldDefinitionList extends FieldDefinitionBase {
   items_type: FieldDefinition;
 }
 
-export type FieldDefinition = FieldDefinitionText | FieldDefinitionObject | FieldDefinitionList;
+export type FieldDefinition = FieldDefinitionText | FieldDefinitionModel | FieldDefinitionObject | FieldDefinitionList;
 
 export interface BulkGenerateInfo {
   name: string;

--- a/inventree_bulk_plugin/frontend/src/utils/types.ts
+++ b/inventree_bulk_plugin/frontend/src/utils/types.ts
@@ -15,6 +15,11 @@ export interface FieldDefinitionModel extends FieldDefinitionBase {
   model: { model: string; limit_choices_to: Record<string, string>; api_url: string };
 }
 
+export interface FieldDefinitionSelect extends FieldDefinitionBase {
+  field_type: "select";
+  options: Record<string, string>;
+}
+
 export interface FieldDefinitionObject extends FieldDefinitionBase {
   field_type: "object";
   fields: Record<string, FieldDefinition>;
@@ -25,7 +30,12 @@ export interface FieldDefinitionList extends FieldDefinitionBase {
   items_type: FieldDefinition;
 }
 
-export type FieldDefinition = FieldDefinitionText | FieldDefinitionModel | FieldDefinitionObject | FieldDefinitionList;
+export type FieldDefinition =
+  | FieldDefinitionText
+  | FieldDefinitionModel
+  | FieldDefinitionSelect
+  | FieldDefinitionObject
+  | FieldDefinitionList;
 
 export interface BulkGenerateInfo {
   name: string;

--- a/inventree_bulk_plugin/frontend/src/utils/types.ts
+++ b/inventree_bulk_plugin/frontend/src/utils/types.ts
@@ -3,6 +3,8 @@ export interface FieldDefinitionBase {
   description: null | string;
   required: boolean;
   model: null | { model: string; limit_choices_to: Record<string, string> };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default?: any;
 }
 
 export interface FieldDefinitionText extends FieldDefinitionBase {

--- a/inventree_bulk_plugin/frontend/src/utils/types.ts
+++ b/inventree_bulk_plugin/frontend/src/utils/types.ts
@@ -10,7 +10,7 @@ export type GenerateKeys = Record<string, GenerateKey>;
 export interface BulkGenerateInfo {
   name: string;
   template_type: string;
-  generate_type: string;
+  generate_type: "single" | "tree";
   fields: GenerateKeys;
 }
 

--- a/inventree_bulk_plugin/frontend/src/utils/types.ts
+++ b/inventree_bulk_plugin/frontend/src/utils/types.ts
@@ -1,17 +1,31 @@
-export interface GenerateKey {
+export interface FieldDefinitionBase {
   name: string;
-  field_type: "text" | "boolean" | "number";
-  required: boolean;
   description: null | string;
+  required: boolean;
+  model: null | { model: string; limit_choices_to: Record<string, string> };
 }
 
-export type GenerateKeys = Record<string, GenerateKey>;
+export interface FieldDefinitionText extends FieldDefinitionBase {
+  field_type: "text" | "boolean" | "number" | "model";
+}
+
+export interface FieldDefinitionObject extends FieldDefinitionBase {
+  field_type: "object";
+  fields: Record<string, FieldDefinition>;
+}
+
+export interface FieldDefinitionList extends FieldDefinitionBase {
+  field_type: "list";
+  items_type: FieldDefinition;
+}
+
+export type FieldDefinition = FieldDefinitionText | FieldDefinitionObject | FieldDefinitionList;
 
 export interface BulkGenerateInfo {
   name: string;
   template_type: string;
   generate_type: "single" | "tree";
-  fields: GenerateKeys;
+  fields: Record<string, FieldDefinition>;
 }
 
 export interface TemplateModel {
@@ -28,12 +42,14 @@ export interface BulkDefinitionSchema {
   output: BulkDefinitionChild;
 }
 
+export type FieldType = string | { [key: string]: FieldType } | FieldType[];
+
 export interface BulkDefinitionChild {
   parent_name_match?: string;
   extends?: string;
   dimensions: (string | null)[];
   count: (string | null)[];
-  generate: Record<string, string>;
+  generate: Record<string, FieldType>;
   child?: BulkDefinitionChild;
   childs?: BulkDefinitionChild[];
 }

--- a/inventree_bulk_plugin/models.py
+++ b/inventree_bulk_plugin/models.py
@@ -10,7 +10,7 @@ from .BulkGenerator.BulkGenerator import BulkGenerator
 
 def validate_template(value):
     try:
-        BulkGenerator(json.loads(value)).validate(True)
+        BulkGenerator(json.loads(value), fields={}).validate(True)
         return value
     except PyDanticValidationError as e:
         raise ValidationError(str(e))

--- a/inventree_bulk_plugin/serializers.py
+++ b/inventree_bulk_plugin/serializers.py
@@ -37,6 +37,7 @@ class FieldDefinitionSerializer(serializers.Serializer):
             "items_type",
             "fields",
             "default",
+            "options",
         ]
 
     name = serializers.CharField()
@@ -45,6 +46,7 @@ class FieldDefinitionSerializer(serializers.Serializer):
     required = serializers.BooleanField()
     model = serializers.SerializerMethodField()
     default = serializers.SerializerMethodField("get_default_method")
+    options = serializers.SerializerMethodField("get_options_method")
 
     def get_fields(self):
         fields = super().get_fields()
@@ -72,6 +74,17 @@ class FieldDefinitionSerializer(serializers.Serializer):
             return func()
         if default is not None:
             return default
+        return None
+
+    def get_options_method(self, obj):
+        options = getattr(obj, "options", None)
+        get_options = getattr(obj, "get_options", None)
+
+        # try to get options value from associated BulkCreateObject class
+        if get_options is not None and (func := getattr(self.root.instance, get_options, None)):
+            return func()
+        if options is not None:
+            return options
         return None
 
 

--- a/inventree_bulk_plugin/serializers.py
+++ b/inventree_bulk_plugin/serializers.py
@@ -57,7 +57,11 @@ class FieldDefinitionSerializer(serializers.Serializer):
         if model is None:
             return None
 
-        return {"model": model[0], "limit_choices_to": model[1]}
+        return {
+            "model": model[0],
+            "limit_choices_to": model[1],
+            "api_url": obj.get_api_url(),
+        }
 
     def get_default_method(self, obj):
         default = getattr(obj, "default", None)

--- a/inventree_bulk_plugin/serializers.py
+++ b/inventree_bulk_plugin/serializers.py
@@ -83,8 +83,8 @@ class FieldDefinitionSerializer(serializers.Serializer):
         # try to get options value from associated BulkCreateObject class
         if get_options is not None:
             return get_options()
-        if options is not None:
-            return options
+        if options is not None:  # pragma: no cover
+            return options  # currently there is no option that needs this case
         return None
 
 

--- a/inventree_bulk_plugin/serializers.py
+++ b/inventree_bulk_plugin/serializers.py
@@ -34,6 +34,8 @@ class FieldDefinitionSerializer(serializers.Serializer):
             "description",
             "required",
             "model",
+            "items_type",
+            "fields",
         ]
 
     name = serializers.CharField()
@@ -41,6 +43,12 @@ class FieldDefinitionSerializer(serializers.Serializer):
     description = serializers.CharField()
     required = serializers.BooleanField()
     model = serializers.SerializerMethodField()
+
+    def get_fields(self):
+        fields = super().get_fields()
+        fields["items_type"] = FieldDefinitionSerializer()
+        fields["fields"] = serializers.DictField(child=FieldDefinitionSerializer(read_only=True))
+        return fields
 
     def get_model(self, obj):
         model = getattr(obj, "model", None)

--- a/inventree_bulk_plugin/serializers.py
+++ b/inventree_bulk_plugin/serializers.py
@@ -33,12 +33,21 @@ class FieldDefinitionSerializer(serializers.Serializer):
             "field_type",
             "description",
             "required",
+            "model",
         ]
 
     name = serializers.CharField()
     field_type = serializers.CharField()
     description = serializers.CharField()
     required = serializers.BooleanField()
+    model = serializers.SerializerMethodField()
+
+    def get_model(self, obj):
+        model = getattr(obj, "model", None)
+        if model is None:
+            return None
+
+        return {"model": model[0], "limit_choices_to": model[1]}
 
 
 class BulkCreateObjectSerializer(serializers.Serializer):

--- a/inventree_bulk_plugin/serializers.py
+++ b/inventree_bulk_plugin/serializers.py
@@ -70,8 +70,8 @@ class FieldDefinitionSerializer(serializers.Serializer):
         get_default = getattr(obj, "get_default", None)
 
         # try to get default value from associated BulkCreateObject class
-        if get_default is not None and (func := getattr(self.root.instance, get_default, None)):
-            return func()
+        if get_default is not None:
+            return get_default()
         if default is not None:
             return default
         return None
@@ -81,8 +81,8 @@ class FieldDefinitionSerializer(serializers.Serializer):
         get_options = getattr(obj, "get_options", None)
 
         # try to get options value from associated BulkCreateObject class
-        if get_options is not None and (func := getattr(self.root.instance, get_options, None)):
-            return func()
+        if get_options is not None:
+            return get_options()
         if options is not None:
             return options
         return None
@@ -96,7 +96,6 @@ class BulkCreateObjectSerializer(serializers.Serializer):
             "name",
             "template_type",
             "generate_type",
-            "fields",
         ]
 
         read_only_fields = fields
@@ -104,4 +103,12 @@ class BulkCreateObjectSerializer(serializers.Serializer):
     name = serializers.CharField()
     template_type = serializers.CharField()
     generate_type = serializers.CharField()
+
+
+class BulkCreateObjectDetailSerializer(BulkCreateObjectSerializer):
+    """Serializer for a BulkCreateObjectDetail implementation."""
+
+    class Meta(BulkCreateObjectSerializer.Meta):
+        fields = BulkCreateObjectSerializer.Meta.fields + ["fields"]
+
     fields = serializers.DictField(child=FieldDefinitionSerializer(read_only=True))

--- a/inventree_bulk_plugin/templates/preact-page.html
+++ b/inventree_bulk_plugin/templates/preact-page.html
@@ -1,7 +1,7 @@
 {% load static %}
 {% load inventree_extras %}
 
-{% define "bulk-create-preact-root__"|add:page as dom_root %}
+{% define "bulk-create-preact-root__"|add:page|add:id as dom_root %}
 
 <div id="{{ dom_root }}"></div>
 

--- a/inventree_bulk_plugin/tests/integration/test_InvenTreeBulkPlugin.py
+++ b/inventree_bulk_plugin/tests/integration/test_InvenTreeBulkPlugin.py
@@ -8,7 +8,7 @@ from stock.views import StockLocationDetail
 from part.views import CategoryDetail
 
 from ...models import validate_template
-from ...InvenTreeBulkPlugin import InvenTreeBulkPlugin
+from ...InvenTreeBulkPlugin import InvenTreeBulkPlugin, validate_json
 from ...version import BULK_PLUGIN_VERSION
 
 
@@ -61,3 +61,14 @@ class InvenTreeBulkPluginTestCase(TestCase):
         panels = bulk_plugin.get_custom_panels(CategoryDetail(), None)
         assert_contains_by_title("Category bulk creation", panels)
         assert_contains_by_title("Part bulk creation", panels)
+
+    def test_validate_json(self):
+        valid_json = '{"ts": 13}'
+        not_valid_json = '{"ts""13"}'
+
+        # no error, should pass validator
+        valid_json(valid_json)
+
+        # should throw an error
+        with self.assertRaises(ValidationError):
+            validate_json(not_valid_json)

--- a/inventree_bulk_plugin/tests/integration/test_InvenTreeBulkPlugin.py
+++ b/inventree_bulk_plugin/tests/integration/test_InvenTreeBulkPlugin.py
@@ -67,7 +67,7 @@ class InvenTreeBulkPluginTestCase(TestCase):
         not_valid_json = '{"ts""13"}'
 
         # no error, should pass validator
-        valid_json(valid_json)
+        validate_json(valid_json)
 
         # should throw an error
         with self.assertRaises(ValidationError):

--- a/inventree_bulk_plugin/tests/integration/test_InvenTreeBulkPlugin.py
+++ b/inventree_bulk_plugin/tests/integration/test_InvenTreeBulkPlugin.py
@@ -56,7 +56,7 @@ class InvenTreeBulkPluginTestCase(TestCase):
             self.assertListEqual(["title", "icon", "content", "description"], list(found.keys()))
 
         panels = bulk_plugin.get_custom_panels(StockLocationDetail(), None)
-        assert_contains_by_title("Bulk creation", panels)
+        assert_contains_by_title("Stock bulk creation", panels)
 
         panels = bulk_plugin.get_custom_panels(CategoryDetail(), None)
         assert_contains_by_title("Category bulk creation", panels)

--- a/inventree_bulk_plugin/tests/integration/test_InvenTreeBulkPlugin.py
+++ b/inventree_bulk_plugin/tests/integration/test_InvenTreeBulkPlugin.py
@@ -56,7 +56,7 @@ class InvenTreeBulkPluginTestCase(TestCase):
             self.assertListEqual(["title", "icon", "content", "description"], list(found.keys()))
 
         panels = bulk_plugin.get_custom_panels(StockLocationDetail(), None)
-        assert_contains_by_title("Stock bulk creation", panels)
+        assert_contains_by_title("Location bulk creation", panels)
 
         panels = bulk_plugin.get_custom_panels(CategoryDetail(), None)
         assert_contains_by_title("Category bulk creation", panels)

--- a/inventree_bulk_plugin/tests/integration/test_InvenTreeBulkPlugin.py
+++ b/inventree_bulk_plugin/tests/integration/test_InvenTreeBulkPlugin.py
@@ -59,4 +59,5 @@ class InvenTreeBulkPluginTestCase(TestCase):
         assert_contains_by_title("Bulk creation", panels)
 
         panels = bulk_plugin.get_custom_panels(CategoryDetail(), None)
-        assert_contains_by_title("Bulk creation", panels)
+        assert_contains_by_title("Category bulk creation", panels)
+        assert_contains_by_title("Part bulk creation", panels)

--- a/inventree_bulk_plugin/tests/integration/test_api.py
+++ b/inventree_bulk_plugin/tests/integration/test_api.py
@@ -72,10 +72,10 @@ class InvenTreeBulkPluginAPITestCase(InvenTreeAPITestCase):
             self.assertTrue("name" in generate_info)
             self.assertTrue("template_type" in generate_info)
             self.assertTrue("generate_type" in generate_info)
-            self.assertTrue("fields" in generate_info)
 
         self.assertTrue("STOCK_LOCATION" in template_types)
         self.assertTrue("PART_CATEGORY" in template_types)
+        self.assertTrue("PART" in template_types)
 
     def test_url_bulkcreate_preview(self):
         url = reverse("plugin:inventree-bulk-plugin:api-bulk-create")

--- a/inventree_bulk_plugin/tests/integration/test_api.py
+++ b/inventree_bulk_plugin/tests/integration/test_api.py
@@ -258,7 +258,7 @@ class InvenTreeBulkPluginAPITestCase(InvenTreeAPITestCase):
             }
         }
         response = self.post(url + f"?parent_id={parent.pk}&create=true", schema, expected_code=400)
-        self.assertEqual({"error": "'name' is missing in generated keys"}, response.json())
+        self.assertEqual({"error": "'name' are missing in generated keys."}, response.json())
 
     def _template_url(self, pk=None):
         if pk:

--- a/inventree_bulk_plugin/tests/integration/test_api.py
+++ b/inventree_bulk_plugin/tests/integration/test_api.py
@@ -108,8 +108,8 @@ class InvenTreeBulkPluginAPITestCase(InvenTreeAPITestCase):
 
         response = self.get(url + f"?template_type=PART&parent_id={category.pk}", expected_code=200).json()
         self.assertEqual(response["fields"]["parameters"]["default"], [
-            {"template": str(part_parameter_template1), "value": ""},
-            {"template": str(part_parameter_template2), "value": "10"},
+            {"template": str(part_parameter_template1.pk), "value": ""},
+            {"template": str(part_parameter_template2.pk), "value": "10"},
         ])
 
     def test_url_bulkcreate_preview(self):

--- a/inventree_bulk_plugin/tests/integration/test_api.py
+++ b/inventree_bulk_plugin/tests/integration/test_api.py
@@ -172,7 +172,7 @@ class InvenTreeBulkPluginAPITestCase(InvenTreeAPITestCase):
                 },
             },
         }
-        response = self.post(url + "?parent_id=99999", data, expected_code=404)
+        response = self.post(url + "?parent_id=99999", data, expected_code=400)
 
         # If template_type is provided and parent_id, everything should work and parent context should be used
         parent = StockLocation.objects.create(name="Parent 13", description="Parent description", parent=None)

--- a/inventree_bulk_plugin/tests/integration/test_api.py
+++ b/inventree_bulk_plugin/tests/integration/test_api.py
@@ -77,6 +77,18 @@ class InvenTreeBulkPluginAPITestCase(InvenTreeAPITestCase):
         self.assertTrue("PART_CATEGORY" in template_types)
         self.assertTrue("PART" in template_types)
 
+    def test_url_bulkcreate_info_detail(self):
+        url = reverse("plugin:inventree-bulk-plugin:api-bulk-create")
+
+        self.get(url + "?template_type=NOT_EXISTING_TEMPLATE_TYPE", expected_code=400)
+
+        response = self.get(url + "?template_type=PART", expected_code=200).json()
+        self.assertTrue("name" in response)
+        self.assertTrue("template_type" in response)
+        self.assertEqual(response["template_type"], "PART")
+        self.assertTrue("generate_type" in response)
+        self.assertTrue("fields" in response)
+
     def test_url_bulkcreate_preview(self):
         url = reverse("plugin:inventree-bulk-plugin:api-bulk-create")
 

--- a/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
+++ b/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
@@ -59,7 +59,8 @@ class BulkCreateObjectsUtilsTestCase(TestCase):
 
         # should get correct model instance
         company = Company.objects.create(name="Test")
-        self.assertEqual(cast_model(str(company.pk), field=FieldDefinition("A", model="company.company")), company)
+        self.assertEqual(cast_model(str(company.pk), field=FieldDefinition(
+            "A", model="company.company")), str(company.pk))
 
     def test_cast_select(self):
         options = {"a": "A", "b": "B"}
@@ -72,7 +73,8 @@ class BulkCreateObjectsUtilsTestCase(TestCase):
         self.assertEqual(cast_select("b", field=FieldDefinition("A", field_type="select", options=options)), "b")
 
         # test valid option using get_options
-        self.assertEqual(cast_select("b", field=FieldDefinition("A", field_type="select", get_options=lambda: options)), "b")
+        self.assertEqual(cast_select("b", field=FieldDefinition(
+            "A", field_type="select", get_options=lambda: options)), "b")
 
 
 class FieldDefinitionTestCase(TestCase):

--- a/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
+++ b/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
@@ -1,5 +1,6 @@
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
+from django.contrib.auth.models import User
 
 from company.models import Company, ManufacturerPart, SupplierPart
 from part.models import Part, PartCategory, PartParameterTemplate, PartParameter, PartAttachment
@@ -226,6 +227,7 @@ class BulkCreateObjectTestCase(TestCase):
 class PartBulkCreateObjectTestCase(TestCase):
     def setUp(self):
         self.request = CustomRequestFactory()
+        self.user = User.objects.create_user(username="test", password="test")
 
     def test_create_objects(self):
         InvenTreeSetting.set_setting("INVENTREE_DOWNLOAD_FROM_URL", True, None)
@@ -275,7 +277,9 @@ class PartBulkCreateObjectTestCase(TestCase):
             ({"name": "Test 1", "description": "Test 1 description", **base_data}, []),
         ]
 
-        obj = PartBulkCreateObject(self.request.get(f"/abc?parent_id={category.pk}"))
+        req = self.request.get(f"/abc?parent_id={category.pk}")
+        req.user = self.user
+        obj = PartBulkCreateObject(req)
         obj.get_context()
         obj.create_objects(data)
 

--- a/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
+++ b/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
@@ -1,0 +1,116 @@
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+
+from company.models import Company
+
+from ...bulkcreate_objects import get_model, get_model_instance, FieldDefinition, BulkCreateObject
+
+
+class BulkCreateObjectsUtilsTestCase(TestCase):
+    def test_get_model(self):
+        # no valid format
+        self.assertIsNone(get_model("abc"))
+
+        # not existing app
+        self.assertIsNone(get_model("abc.def"))
+
+        # not existing model
+        self.assertIsNone(get_model("company.def"))
+
+        # valid model
+        self.assertEqual(get_model("company.company"), Company)
+
+        # unstriped special casing string
+        self.assertEqual(get_model("  cOmPaNy.CoMpAnY "), Company)
+
+    def test_get_model_instance(self):
+        supplier_company = Company.objects.create(name="Supplier company", is_supplier=True)
+        customer_company = Company.objects.create(name="Customer company", is_customer=True)
+
+        # simple test
+        self.assertEqual(get_model_instance(Company, supplier_company.pk), supplier_company)
+
+        # test limit_choices with result
+        self.assertEqual(get_model_instance(Company, supplier_company.pk, {"is_supplier": True}), supplier_company)
+
+        # test limit_choices without result
+        with self.assertRaisesRegex(ValueError, "Model 'company.company' where {'pk': " + str(customer_company.pk) + ", 'is_supplier': True} not found at XXX"):
+            get_model_instance(Company, customer_company.pk, {"is_supplier": True}, "at XXX")
+
+
+class FieldDefinitionTestCase(TestCase):
+    def test_auto_typecasts(self):
+        for field_type, cast_func in FieldDefinition.type_casts.items():
+            field = FieldDefinition("A", field_type=field_type)
+            self.assertEqual(field.cast_func, cast_func)
+
+    def test_auto_get_model_class(self):
+        # simple test with only model string
+        field = FieldDefinition("A", field_type="model", model="company.company")
+        self.assertEqual(field.model, ("company.company", {}, Company))
+
+        # test with limit choices
+        field = FieldDefinition("A", field_type="model", model=("company.company", {"is_supplier": True}))
+        self.assertEqual(field.model, ("company.company", {"is_supplier": True}, Company))
+
+        # test with not existing model
+        with self.assertRaisesRegex(ValueError, "Model 'not.existing' not found."):
+            field = FieldDefinition("A", field_type="model", model=("not.existing", {}))
+
+        # test if tuple has len=3, it should touch anything to enable custom usage for fetching non models
+        field = FieldDefinition("A", field_type="model", model=("not.existing", {}, None))
+        self.assertEqual(field.model, ("not.existing", {}, None))
+
+    def test_get_api_url(self):
+        # no model set
+        field = FieldDefinition("A")
+        self.assertIsNone(field.get_api_url())
+
+        # defined api url should take precedence
+        field = FieldDefinition("A", model="company.company", api_url="abcdef")
+        self.assertEqual(field.get_api_url(), "abcdef")
+
+        # get api url from model class if available
+        field = FieldDefinition("A", model="company.company")
+        self.assertEqual(field.get_api_url(), Company.get_api_url())
+
+        # get api url for hardcoded fields
+        for model, url in [("auth.user", "api-user-list"), ("auth.group", "api-group-list")]:
+            field = FieldDefinition("A", model=model)
+            self.assertEqual(field.get_api_url(), reverse(url), f"url should match for {model}")
+
+
+class BulkCreateObjectTestCase(TestCase):
+    def setUp(self):
+        self.request = RequestFactory()
+
+    def test_fields(self):
+        test = self
+
+        my_fields = {
+            "a": FieldDefinition("A")
+        }
+
+        # simple fields
+        class MyBulkCreateObject(BulkCreateObject):
+            name = "My object"
+            template_type = "MY_OBJECT"
+            model = Company
+            fields = my_fields
+
+        my_obj = MyBulkCreateObject(self.request.get("/abc"))
+        self.assertEqual(my_obj.fields, my_fields)
+
+        # via get_fields
+        class MyBulkCreateObject2(BulkCreateObject):
+            name = "My object2"
+            template_type = "MY_OBJECT2"
+            model = Company
+
+            def get_fields(self):
+                test.assertEqual(self.request.path, "/abc")
+                return {**my_fields, "b": FieldDefinition("B")}
+
+        my_obj2 = MyBulkCreateObject2(self.request.get("/abc"))
+        self.assertTrue("a" in my_obj2.fields)
+        self.assertTrue("b" in my_obj2.fields)

--- a/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
+++ b/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
@@ -24,8 +24,8 @@ class BulkCreateObjectsUtilsTestCase(TestCase):
         self.assertEqual(get_model("  cOmPaNy.CoMpAnY "), Company)
 
     def test_get_model_instance(self):
-        supplier_company = Company.objects.create(name="Supplier company", is_supplier=True)
-        customer_company = Company.objects.create(name="Customer company", is_customer=True)
+        supplier_company = Company.objects.create(name="Supplier company", is_supplier=True, is_customer=False)
+        customer_company = Company.objects.create(name="Customer company", is_supplier=False, is_customer=True)
 
         # simple test
         self.assertEqual(get_model_instance(Company, supplier_company.pk), supplier_company)

--- a/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
+++ b/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
@@ -151,6 +151,7 @@ class BulkCreateObjectTestCase(TestCase):
             model = Part
             fields = {
                 "name": FieldDefinition("Name", required=True),
+                "description": FieldDefinition("Description", default="A very long description to work around the sample plugin limitation which is present in testing"),
             }
 
         my_obj = MyBulkCreateObject(self.request.get("/abc"))
@@ -172,6 +173,7 @@ class BulkCreateObjectTestCase(TestCase):
             model = PartCategory
             fields = {
                 "name": FieldDefinition("Name", required=True),
+                "description": FieldDefinition("Description", default="A very long description to work around the sample plugin limitation which is present in testing"),
             }
 
         parent_category = PartCategory.objects.create(name="Parent")
@@ -181,7 +183,7 @@ class BulkCreateObjectTestCase(TestCase):
             [({"name": "Test"}, [({"name": "1"}, []), ({"name": "2"}, [({"name": "1"}, [])])])])
         all_categories = list(PartCategory.objects.all())
         self.assertEqual(len(created_categories), 4)
-        self.assertEqual(len(all_categories), 4)
+        self.assertEqual(len(all_categories), 5)
 
         expected = ["Test", "Test/1", "Test/2", "Test/2/1"]
 

--- a/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
+++ b/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
@@ -51,28 +51,28 @@ class BulkCreateObjectsUtilsTestCase(TestCase):
 
     def test_cast_model(self):
         # shouldn't change anything if field is no model field or uses custom processor
-        self.assertEqual(cast_model("10", FieldDefinition("A")), "10")
-        self.assertEqual(cast_model("10", FieldDefinition("A", model=("abc", {}, None))), "10")
+        self.assertEqual(cast_model("10", field=FieldDefinition("A")), "10")
+        self.assertEqual(cast_model("10", field=FieldDefinition("A", model=("abc", {}, None))), "10")
 
         with self.assertRaises(ValueError):
-            cast_model("999999", FieldDefinition("A", model="company.company"))
+            cast_model("999999", field=FieldDefinition("A", model="company.company"))
 
         # should get correct model instance
         company = Company.objects.create(name="Test")
-        self.assertEqual(cast_model(str(company.pk), FieldDefinition("A", model="company.company")), company)
+        self.assertEqual(cast_model(str(company.pk), field=FieldDefinition("A", model="company.company")), company)
 
     def test_cast_select(self):
         options = {"a": "A", "b": "B"}
 
         # test not valid option
         with self.assertRaisesRegex(ValueError, "'c' is not a valid option, choose one of: a, b."):
-            cast_select("c", FieldDefinition("A", field_type="select", options=options))
+            cast_select("c", field=FieldDefinition("A", field_type="select", options=options))
 
         # test valid option
-        self.assertEqual(cast_select("b", FieldDefinition("A", field_type="select", options=options)), "b")
+        self.assertEqual(cast_select("b", field=FieldDefinition("A", field_type="select", options=options)), "b")
 
         # test valid option using get_options
-        self.assertEqual(cast_select("b", FieldDefinition("A", field_type="select", get_options=lambda: options)), "b")
+        self.assertEqual(cast_select("b", field=FieldDefinition("A", field_type="select", get_options=lambda: options)), "b")
 
 
 class FieldDefinitionTestCase(TestCase):

--- a/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
+++ b/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from company.models import Company, ManufacturerPart, SupplierPart
 from part.models import Part, PartCategory, PartParameterTemplate, PartParameter, PartAttachment
 from stock.models import StockLocation, StockItem
+from common.models import InvenTreeSetting
 
 from ...bulkcreate_objects import get_model, get_model_instance, FieldDefinition, BulkCreateObject, PartBulkCreateObject
 
@@ -227,6 +228,8 @@ class PartBulkCreateObjectTestCase(TestCase):
         self.request = CustomRequestFactory()
 
     def test_create_objects(self):
+        InvenTreeSetting.set_setting("INVENTREE_DOWNLOAD_FROM_URL", True, None)
+
         parameter_template = PartParameterTemplate.objects.create(name="Test", units="kg", description="Test template")
         supplier_company = Company.objects.create(name="Supplier", is_supplier=True)
         manufacturer_company = Company.objects.create(name="Supplier", is_supplier=False, is_manufacturer=True)

--- a/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
+++ b/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
@@ -364,7 +364,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
             "input": {},
             "templates": [],
             "output": {"generate": {"number_field": "42"}, }
-        }, {"number_field": BaseFieldDefinition("number_field", cast_func=int)}).generate()
+        }, {"number_field": BaseFieldDefinition("number_field", cast_func=lambda x, **kwargs: int(x))}).generate()
 
         self.assertEqual(res[0][0]["number_field"], 42)
 

--- a/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
+++ b/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
@@ -26,7 +26,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                         },
                         "childs": []
                     }
-                }).generate()
+                }, fields={"name": BaseFieldDefinition("Name")}).generate()
 
                 for e, (r, child) in zip(exp, res):
                     self.assertDictEqual({"name": f"before{e}after"}, r)
@@ -60,7 +60,11 @@ class BulkGeneratorTestCase(unittest.TestCase):
                 },
                 "childs": []
             }
-        }).generate()
+        }, fields={
+            "name": BaseFieldDefinition("Name"),
+            "description": BaseFieldDefinition("Description"),
+            "abc": BaseFieldDefinition("ABC")}
+        ).generate()
 
         self.assertEqual(len(res), 10, "should generate 10 elements")
 
@@ -112,7 +116,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                 "output": {
                     "extends": "Drawer",
                 }
-            }).generate()
+            }, fields={}).generate()
 
     def test_without_dimensions(self):
         res = BulkGenerator({
@@ -127,7 +131,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                 },
                 "childs": []
             }
-        }).generate()
+        }, fields={"name": BaseFieldDefinition("Name")}).generate()
 
         self.assertEqual(1, len(res))
         self.assertDictEqual({"name": "test"}, res[0][0])
@@ -146,7 +150,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                 },
                 "childs": []
             }
-        }).generate()
+        }, fields={"name": BaseFieldDefinition("Name")}).generate()
 
         self.assertEqual(2, len(res))
         self.assertDictEqual({"name": "Hello 1"}, res[0][0])
@@ -168,7 +172,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                     },
                     "childs": []
                 }
-            }).generate()
+            }, fields={"name": BaseFieldDefinition("Name")}).generate()
 
     def test_invalid_template_on_dimensions_render(self):
         cases = [
@@ -191,7 +195,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                             },
                             "childs": []
                         }
-                    }).generate()
+                    }, fields={"name": BaseFieldDefinition("Name")}).generate()
 
     def test_merge_base_child_to_childs(self):
         res = BulkGenerator({
@@ -207,7 +211,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                     {"generate": {"description": "ghi"}}
                 ]
             }
-        }).generate()
+        }, fields={"name": BaseFieldDefinition("Name"), "description": BaseFieldDefinition("Description")}).generate()
 
         self.assertEqual(1, len(res))
         self.assertDictEqual({"name": "abc"}, res[0][0])
@@ -227,7 +231,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                 "child": {"generate": {"name": "def", "description": "jkl"}},
                 "childs": []
             }
-        }).generate()
+        }, fields={"name": BaseFieldDefinition("Name"), "description": BaseFieldDefinition("Description")}).generate()
 
         self.assertEqual(1, len(res))
         self.assertDictEqual({"name": "abc"}, res[0][0])
@@ -255,7 +259,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                     }
                 ]
             }
-        }).generate()
+        }, fields={"name": BaseFieldDefinition("Name"), "a": BaseFieldDefinition("A")}).generate()
 
         self.assertEqual(9, len(res))
         for i, (e, childs) in enumerate(res):
@@ -278,7 +282,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                         },
                     ]
                 }
-            }).generate()
+            }, fields={"name": BaseFieldDefinition("Name")}).generate()
 
     def test_error_in_parent_name_match(self):
         with self.assertRaisesRegex(ValueError, "Invalid generator template '{{something.not.existing}}'"):
@@ -297,7 +301,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                         },
                     ]
                 }
-            }).generate()
+            }, fields={"name": BaseFieldDefinition("Name"), "a": BaseFieldDefinition("A")}).generate()
 
     def test_parent_context(self):
         res = BulkGenerator({
@@ -314,6 +318,10 @@ class BulkGeneratorTestCase(unittest.TestCase):
                     }
                 }
             }
+        }, fields={
+            "name": BaseFieldDefinition("Name"),
+            "parent_name": BaseFieldDefinition("parent_name"),
+            "parent_parent_dim_1": BaseFieldDefinition("parent_parent_dim_1"),
         }).generate()
 
         self.assertListEqual([({'name': 'First A'}, [({'name': 'Second '}, [({'parent_name': 'Second ', 'parent_parent_dim_1': 'A'}, [])])]), ({
@@ -329,6 +337,10 @@ class BulkGeneratorTestCase(unittest.TestCase):
                 "count": [10, 2],
                 "generate": {"length": "{{len}}", "dim1len": "{{dim.1.len}}", "dim2len": "{{dim.2.len}}"},
             }
+        }, fields={
+            "length": BaseFieldDefinition("Length"),
+            "dim1len": BaseFieldDefinition("dim1len"),
+            "dim2len": BaseFieldDefinition("dim2len"),
         }).generate()
 
         self.assertEqual(20, len(res))
@@ -338,13 +350,13 @@ class BulkGeneratorTestCase(unittest.TestCase):
             self.assertEqual("2", e['dim2len'])
 
     def test_not_allowed_field(self):
-        with self.assertRaisesRegex(ValueError, "'NOT_ALLOWED_KEY' is not allowed to be generated"):
-            BulkGenerator({
-                "version": "1.0.0",
-                "input": {},
-                "templates": [],
-                "output": {"generate": {"NOT_ALLOWED_KEY": "1"}, }
-            }, {"BBBB": BaseFieldDefinition("BBBB")}).generate()
+        gen = BulkGenerator({
+            "version": "1.0.0",
+            "input": {},
+            "templates": [],
+            "output": {"generate": {"NOT_ALLOWED_KEY": "1"}, }
+        }, {"BBBB": BaseFieldDefinition("BBBB")}).generate()
+        self.assertEqual(gen, [({}, [])])
 
     def test_cast_field(self):
         res = BulkGenerator({
@@ -357,7 +369,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
         self.assertEqual(res[0][0]["number_field"], 42)
 
     def test_required_field(self):
-        with self.assertRaisesRegex(ValueError, "'required_field' is a required field, but template returned empty string"):
+        with self.assertRaisesRegex(ValueError, "'required_field' is a required field, but template '' returned empty string"):
             BulkGenerator({
                 "version": "1.0.0",
                 "input": {},
@@ -365,7 +377,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                 "output": {"generate": {"required_field": ""}, }
             }, {"required_field": BaseFieldDefinition("required_field", required=True)}).generate()
 
-        with self.assertRaisesRegex(ValueError, "'name' is missing in generated keys"):
+        with self.assertRaisesRegex(ValueError, "'name' are missing in generated keys"):
             BulkGenerator({
                 "version": "1.0.0",
                 "input": {},
@@ -373,7 +385,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                 "output": {"generate": {"description": ""}, }
             }, {"name": BaseFieldDefinition("name", required=True)}).generate()
 
-        with self.assertRaisesRegex(ValueError, "'name' is a required field, but template returned empty string"):
+        with self.assertRaisesRegex(ValueError, "'name' is a required field, but template '' returned empty string"):
             BulkGenerator({
                 "version": "1.0.0",
                 "input": {},

--- a/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
+++ b/inventree_bulk_plugin/tests/unit/test_BulkGenerator.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ...BulkGenerator.BulkGenerator import BulkGenerator, FieldDefinition, apply_template
+from ...BulkGenerator.BulkGenerator import BulkGenerator, BaseFieldDefinition, apply_template
 from ...BulkGenerator.validations import BulkDefinitionChild, BulkDefinitionChildTemplate
 
 
@@ -344,7 +344,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                 "input": {},
                 "templates": [],
                 "output": {"generate": {"NOT_ALLOWED_KEY": "1"}, }
-            }, {"BBBB": FieldDefinition("BBBB")}).generate()
+            }, {"BBBB": BaseFieldDefinition("BBBB")}).generate()
 
     def test_cast_field(self):
         res = BulkGenerator({
@@ -352,7 +352,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
             "input": {},
             "templates": [],
             "output": {"generate": {"number_field": "42"}, }
-        }, {"number_field": FieldDefinition("number_field", cast_func=int)}).generate()
+        }, {"number_field": BaseFieldDefinition("number_field", cast_func=int)}).generate()
 
         self.assertEqual(res[0][0]["number_field"], 42)
 
@@ -363,7 +363,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                 "input": {},
                 "templates": [],
                 "output": {"generate": {"required_field": ""}, }
-            }, {"required_field": FieldDefinition("required_field", required=True)}).generate()
+            }, {"required_field": BaseFieldDefinition("required_field", required=True)}).generate()
 
         with self.assertRaisesRegex(ValueError, "'name' is missing in generated keys"):
             BulkGenerator({
@@ -371,7 +371,7 @@ class BulkGeneratorTestCase(unittest.TestCase):
                 "input": {},
                 "templates": [],
                 "output": {"generate": {"description": ""}, }
-            }, {"name": FieldDefinition("name", required=True)}).generate()
+            }, {"name": BaseFieldDefinition("name", required=True)}).generate()
 
         with self.assertRaisesRegex(ValueError, "'name' is a required field, but template returned empty string"):
             BulkGenerator({
@@ -379,4 +379,4 @@ class BulkGeneratorTestCase(unittest.TestCase):
                 "input": {},
                 "templates": [],
                 "output": {"generate": {"name": "", "description": "AA"}, }
-            }, {"name": FieldDefinition("name", required=True), "description": FieldDefinition("description")}).generate()
+            }, {"name": BaseFieldDefinition("name", required=True), "description": BaseFieldDefinition("description")}).generate()

--- a/inventree_bulk_plugin/tests/unit/test_utils.py
+++ b/inventree_bulk_plugin/tests/unit/test_utils.py
@@ -15,13 +15,17 @@ class UtilsTestCase(unittest.TestCase):
                 self.assertEqual(version_tuple(case), expected)
 
     def test_str2bool(self):
-        truthy = ['1', 'y', 'yes', 't', 'true', 'ok', 'on']
-        falsy = ["any", "other", "word", "false", "", "0", "n", "no", "f", "off"]
+        truthy = ['1', 'y', 'yes', 't', 'true', 'ok', 'on', "YeS", "TrUe"]
+        falsy = ['0', 'n', 'no', 'f', 'false', 'off', "FaLsE"]
+        error = ["any", "other", "word", "WoRd", ""]
 
         for t in truthy:
             self.assertTrue(str2bool(t), f"'{t}' should be True")
         for f in falsy:
             self.assertFalse(str2bool(f), f"'{f}' should be False")
+        for e in error:
+            with self.assertRaises(ValueError):
+                str2bool(e)
 
     def test_str2int(self):
         self.assertEqual(42, str2int("42"))

--- a/inventree_bulk_plugin/tests/unit/test_utils.py
+++ b/inventree_bulk_plugin/tests/unit/test_utils.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ...BulkGenerator.utils import version_tuple, str2bool, str2int
+from ...BulkGenerator.utils import version_tuple, str2bool, str2int, str2float
 
 
 class UtilsTestCase(unittest.TestCase):
@@ -31,3 +31,10 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(42, str2int("42"))
         self.assertEqual(None, str2int("abc"))
         self.assertEqual(13, str2int("abc", 13))
+
+    def test_str2float(self):
+        self.assertEqual(42.14, str2float("42.14"))
+        self.assertEqual(42.0, str2float("42"))
+        self.assertEqual(None, str2float("abc"))
+        self.assertEqual(13.0, str2float("abc", 13))
+        self.assertEqual(13.0, str2float("abc", 13.0))

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ ignore =
 	N802
 	# Missing docstrings
 	D100,D101,D102,D103,D104,D105,D106,D107
+	C901
 exclude = .git,__pycache__,dist,build,test.py,*.egg-info/**,.eggs
 max-complexity = 20
 max-line-length = 120


### PR DESCRIPTION
Allow to bulk create also parts including parameters, image, notes, ...

## TODO

- [x] refactor `FieldDefinition` out of BulkGenerator module => apply model_instance in post init
- [x] add select helper for model type fields to UI
- [x] add select helper for image fields to UI (images from remote url)
- [x] add list/object field type to backend and UI (required for `parameters` field)
- [x] load default parameters for category
- [x] add `attachment` field (download from url missing - download before creating parts by extending `create_objects` so download happens outside of db transaction)
- [x] add `stock` field
- [x] add `supplier` field
- [x] add `manufacturer` field
- [x] use creation_user
- [x] add model type field to PartCategory
- [x] make `get_custom_panels` method more generic
- [x] add required check to list and dict if not present in generate instead of always return None
- [x] Add download image from url function
- [x] add preview for nested/native (model, image, ...) fields in preview table
- [x] Undefined description render for child if key is only used in parent
- [x] Template detection for empty bools does not work
- [x] validate models if object with that pk and limit options exist in `cast_func` which can be used as a validator too
- [x] validate select field option on server, important for stock status
- [x] use select field for stock status
- [x] ~~docs~~ -> moved to other PR
  - [x] ~~new generate fields with native/template selection~~
  - [x] ~~new generate dialog with inputs~~
  - [x] ~~add section describing where to find the panels~~
  - [x] ~~context that is available~~
- [x] tests
- [x] https://github.com/inventree/InvenTree/pull/5480

resolves #45 