### PR TITLE
Part improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,6 @@ You can use [Jinja2 templating](https://jinja.palletsprojects.com/en/3.1.x/templ
 ##### Global context
 
 - `inp.<key>` - Access [input variables](#input), e.g. (`{{inp.drawer_count|int / 2}}`)
-- `global.<...>` - Access any variable defined in [global context](#global-context)
 
 ##### Extra useful filters
 
@@ -213,7 +212,7 @@ Select a template to extend from
 
 ##### Global context
 
-Global context can be used to set up some more complex variables and reuse them between fields. Under the hood this template gets imported as `global` by prepending `{% import global_context_template as global with context %}` to every generate field. Therefore you can also use the dimensions and every available context variable there too.
+Global context can be used to set up some more complex variables and reuse them between fields. Under the hood this template gets imported as `global` by prepending `{% import global_context_template as global with context %}` to every generate field. Therefore you can also use the dimensions and every available context variable there too. But note that the defined variables are only valid in that parent they are defined in, not in their childs. This is a limitation of the import function of jinja2 templates.
 
 ##### Dimensions/Count
 
@@ -253,7 +252,7 @@ Child's are a way to add some nesting to your bulk creation tree. You can use th
 
 ### Generation types
 
-You can bulk create sub-stocklocations, sub-partcategories and parts with there different options. All of those are tree objects, that means objects that can have childs and extend from templates that can be defined.
+You can bulk create sub-stocklocations, sub-partcategories and [parts](#parts) with there different options. All of those are tree objects, that means objects that can have childs and extend from templates that can be defined.
 
 <!-- These objects can be categorized into two different generation groups, [Tree objects](#tree-objects) and [normal objects](#normal-objects).  -->
 
@@ -268,6 +267,7 @@ For all of those, the following context is available.
 | `par.dim.<x>`    | parents's dimensions                                                          |
 | `par.gen.<name>` | parent's generated fields (e.g. to reuse the parents name `{{par.gen.name}}`) |
 | `par.par.<...>`  | parent's parent context, can be nested deeply                                 |
+| `global.<...>`   | Access any variable defined in [global context](#global-context)              |
 
 <!--
 Currently there is only one type

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The bulk creation editor helps you to define the generation schema.
 
 You can use [Jinja2 templating](https://jinja.palletsprojects.com/en/3.1.x/templates/) in every field (except in the `input` section). You can also use filters to manipulate the dimension output.
 
-##### Global context
+##### Global jinja2 context
 
 - `inp.<key>` - Access [input variables](#input), e.g. (`{{inp.drawer_count|int / 2}}`)
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Normal objects are objects that don't have a tree structure and therefore don't 
 
 ##### Parts
 
-Parts use the tree generation feature for part variant. You can either generate variants for an already created template part by using the "variants of" attribute, or create a template part with variants by using the childs feature. The "variant of" field then gets automatically assigned the parent part if its not set for the child. The only thing you need to make sure is that the parent part has set the `is_template: true` option, otherwise creation will fail. The plugin then tries to copy unset fields from the template part if they are not set for the child. Parameters get copied too, even there are parameters defined for the child.
+Parts use the tree generation feature for part variant. You can either generate variants for an already created template part by using the "variants of" attribute (note that for the root generate element, templating is not supported in this field), or create a template part with variants by using the childs feature. The "variant of" field then gets automatically assigned the parent part if its not set for the child. The only thing you need to make sure is that the parent part has set the `is_template: true` option, otherwise creation will fail. The plugin then tries to copy unset fields from the template part if they are not set for the child. Parameters get copied too, even there are parameters defined for the child.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -253,30 +253,45 @@ Child's are a way to add some nesting to your bulk creation tree. You can use th
 
 ### Generation types
 
-You can bulk create sub-stocklocations, sub-partcategories and parts with there different options. These objects can be categorized into two different generation groups, [Tree objects](#tree-objects) and [normal objects](#normal-objects). For all of those, the following context is available.
+You can bulk create sub-stocklocations, sub-partcategories and parts with there different options. All of those are tree objects, that means objects that can have childs and extend from templates that can be defined.
 
-| Key           | Description                                                                |
-| ------------- | -------------------------------------------------------------------------- |
-| `len`         | count of elements this child will generate                                 |
-| `dim.<x>`     | x-th dimension, one-based (e.g. `{{dim.1}}` to access the first dimension) |
-| `dim.<x>.len` | count of items the x-th dimension has                                      |
+<!-- These objects can be categorized into two different generation groups, [Tree objects](#tree-objects) and [normal objects](#normal-objects).  -->
 
-#### Tree objects
-
-Tree objects are objects that can have childs and use templates. Currently "stock locations" and "part categories" are supported. In addition to the default context, the following attributes are also available in the context.
+For all of those, the following context is available.
 
 | Key              | Description                                                                   |
 | ---------------- | ----------------------------------------------------------------------------- |
+| `len`            | count of elements this child will generate                                    |
+| `dim.<x>`        | x-th dimension, one-based (e.g. `{{dim.1}}` to access the first dimension)    |
+| `dim.<x>.len`    | count of items the x-th dimension has                                         |
 | `par.<...>`      | parent's context                                                              |
 | `par.dim.<x>`    | parents's dimensions                                                          |
 | `par.gen.<name>` | parent's generated fields (e.g. to reuse the parents name `{{par.gen.name}}`) |
 | `par.par.<...>`  | parent's parent context, can be nested deeply                                 |
 
+<!--
+Currently there is only one type
+#### Tree objects
+Tree objects are objects that can have childs and use templates. Currently "stock locations" and "part categories" are supported. In addition to the default context, the following attributes are also available in the context.
+| Key              | Description                                                                   |
+| ---------------- | ----------------------------------------------------------------------------- |
+
 #### Normal objects
 
 Normal objects are objects that don't have a tree structure and therefore don't need childs and templates. Currently "parts" is the only supported object. There is no additional context.
+-->
 
 ##### Parts
+
+Parts use the tree generation feature for part variant. You can either generate variants for an already created template part by using the "variants of" attribute, or create a template part with variants by using the childs feature. The "variant of" field then gets automatically assigned the parent part if its not set for the child. The only thing you need to make sure is that the parent part has set the `is_template: true` option, otherwise creation will fail. The plugin then tries to copy unset fields from the template part if they are not set for the child. Parameters get copied too, even there are parameters defined for the child.
+
+Example:
+
+<!-- prettier-ignore-start -->
+```json
+{"name":"","template_type":"PART","template":{"version":"1.0.0","input":{},"templates":[],"output":{"parent_name_match":"true","dimensions":[],"count":[],"generate":{"name":"Wall paint","description":"This is awesome paint","is_template":true},"childs":[{"parent_name_match":"true","dimensions":["red,blue,green"],"count":[""],"generate":{"name":"{{par.gen.name}} - {{dim.1}}"}}]}}}
+```
+<!-- prettier-ignore-end -->
 
 Parts have an additional context:
 

--- a/inventree_bulk_plugin/bulkcreate_objects.py
+++ b/inventree_bulk_plugin/bulkcreate_objects.py
@@ -431,7 +431,7 @@ class PartBulkCreateObject(BulkCreateObject[Part]):
 
         # define fields that should be skipped for duplicating
         skip_duplicate_fields = ["parameters", "attachments", "supplier",
-                                 "manufacturer", "stock", "related_parts", "default_supplier"]
+                                 "manufacturer", "stock", "related_parts", "default_supplier", "category", "variant_of", "is_template"]
         if not InvenTreeSetting.get_setting("PART_ALLOW_DUPLICATE_IPN"):
             skip_duplicate_fields.append("IPN")
 
@@ -448,7 +448,11 @@ class PartBulkCreateObject(BulkCreateObject[Part]):
                     # skip copying specific fields
                     if k in skip_duplicate_fields:
                         continue
-                    data[0][k] = value
+
+                    if k == "image":
+                        data[0][k] = value.name
+                    else:
+                        data[0][k] = value
 
         # use local image if available
         image = data[0].pop("image", None)

--- a/inventree_bulk_plugin/bulkcreate_objects.py
+++ b/inventree_bulk_plugin/bulkcreate_objects.py
@@ -364,6 +364,7 @@ class PartBulkCreateObject(BulkCreateObject[Part]):
                 items_type=FieldDefinition(
                     "",
                     field_type="model",
+                    required=True,
                     model="part.part",
                     allow_multiple=True,
                 )

--- a/inventree_bulk_plugin/bulkcreate_objects.py
+++ b/inventree_bulk_plugin/bulkcreate_objects.py
@@ -577,10 +577,10 @@ class PartBulkCreateObject(BulkCreateObject[Part]):
         self.parent = None
 
         # try to add template part (of which this part is a variant of) as 'par.gen.<...>' context
-        schema = self.request.data.get("template", None)
+        schema = self.request.data.get("template", {})
         if not isinstance(schema, dict):
             schema = json.loads(schema)
-        if variant_of := schema["output"]["generate"].get("variant_of", None):
+        if variant_of := schema.get("output", {}).get("generate", {}).get("variant_of", None):
             template_part = get_model_instance(Part, variant_of, {"is_template": True}, "for variant_of field")
             self.parent = template_part  # set parent, used in self.create_objects(...) later
             ctx["gen"] = {key: getattr(template_part, key) for key in self.fields.keys() if hasattr(template_part, key)}

--- a/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
@@ -252,7 +252,8 @@ const getTemplateHelpTexts = (fieldDefinition: FieldDefinition): string => {
     return "Use a template that evaluates to something float like (e.g. '3.1415').";
   }
   if (fieldDefinition.field_type === "model") {
-    return "Use a template that evaluates to a valid id for this model (e.g. '42').";
+    const extraString = fieldDefinition.allow_multiple ? ` The filters can also return multiple objects.` : "";
+    return `Use a template that evaluates to a valid id for this model (e.g. '42') or a json string containing django model filters (e.g. {"name": "R_10k_0808_10%"}).${extraString}`;
   }
   if (fieldDefinition.field_type === "select") {
     return `Use a template that evaluates to a valid option from the select field. Available options: ${Object.keys(

--- a/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
@@ -252,8 +252,10 @@ const getTemplateHelpTexts = (fieldDefinition: FieldDefinition): string => {
     return "Use a template that evaluates to something float like (e.g. '3.1415').";
   }
   if (fieldDefinition.field_type === "model") {
-    const extraString = fieldDefinition.allow_multiple ? ` The filters can also return multiple objects.` : "";
-    return `Use a template that evaluates to a valid id for this model (e.g. '42') or a json string containing django model filters (e.g. {"name": "R_10k_0808_10%"}).${extraString}`;
+    const extraString = fieldDefinition.allow_multiple
+      ? "The filters can also return multiple objects."
+      : "The filters must return only one object.";
+    return `Use a template that evaluates to a valid id for this model (e.g. '42') or a json string containing django model filters (e.g. {"name": "R_10k_0808_10%"} or {"name__startswith": "R_"}), but be aware that the preview table may not work correctly due to API limitations, but bulk create will work correctly then. ${extraString}`;
   }
   if (fieldDefinition.field_type === "select") {
     return `Use a template that evaluates to a valid option from the select field. Available options: ${Object.keys(

--- a/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/GenerateKeys.tsx
@@ -255,7 +255,7 @@ const getTemplateHelpTexts = (fieldDefinition: FieldDefinition): string => {
     const extraString = fieldDefinition.allow_multiple
       ? "The filters can also return multiple objects."
       : "The filters must return only one object.";
-    return `Use a template that evaluates to a valid id for this model (e.g. '42') or a json string containing django model filters (e.g. {"name": "R_10k_0808_10%"} or {"name__startswith": "R_"}), but be aware that the preview table may not work correctly due to API limitations, but bulk create will work correctly then. ${extraString}`;
+    return `Use a template that evaluates to a valid id for this model (e.g. '42') or a json string containing django model filters (e.g. {"name": "R_10k_0808_10%"} or {"name__startswith": "R_"}), but be aware that the preview table may not work correctly due to API limitations. Bulk create will work correctly then. ${extraString}`;
   }
   if (fieldDefinition.field_type === "select") {
     return `Use a template that evaluates to a valid option from the select field. Available options: ${Object.keys(

--- a/inventree_bulk_plugin/frontend/src/components/PreviewTable.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/PreviewTable.tsx
@@ -168,8 +168,8 @@ export const PreviewTable = ({ template, height, parentId, bulkGenerateInfo }: P
             .map(([key, f]) => ({
               field: key,
               title: f.name,
-              formatter: (value: FieldType, _row: Record<string, FieldType>, index: number) =>
-                format(f, value, `table-${id}-field-${index}`),
+              formatter: (value: FieldType, _row: Record<string, FieldType>, index: number, cellName: string) =>
+                format(f, value, `table-${id}-field-${index}-${cellName}`),
             })),
           { field: "path", title: "Path" },
         ],

--- a/inventree_bulk_plugin/frontend/src/components/PreviewTable.tsx
+++ b/inventree_bulk_plugin/frontend/src/components/PreviewTable.tsx
@@ -63,14 +63,22 @@ export const PreviewTable = ({ template, height, parentId, bulkGenerateInfo }: P
                 return customModelProcessors[fieldDefinition.model.model].render(field);
               }
 
-              if (!field.pk) {
-                return "";
-              }
-              const modelName = fieldDefinition.model.model.toLowerCase().split(".").at(-1);
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const renderOne = (f: any) => {
+                if (!f.pk) {
+                  return "";
+                }
+                const modelName = fieldDefinition.model.model.toLowerCase().split(".").at(-1);
 
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
-              return `${renderModelData("", modelName, field, {})} <span>(${field.pk})</span>`;
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                return `${renderModelData("", modelName, f, {})} <span>(${f.pk})</span>`;
+              };
+
+              if (fieldDefinition.allow_multiple && Array.isArray(field)) {
+                return `<li>${field.map(renderOne).join("</li><li>")}</li>`;
+              }
+              return renderOne(field);
             })();
 
             const cell = document.getElementById(cellId);
@@ -91,20 +99,37 @@ export const PreviewTable = ({ template, height, parentId, bulkGenerateInfo }: P
             }
             cache[cacheKey].push(handleSuccess);
           } else {
-            const url = `${fieldDefinition.model.api_url}/${value}/`.replace("//", "/");
+            const cacheKey = `~get-api-${JSON.stringify(value)}`;
+            let urlPath = `${value}/`;
+            let filters = { ...fieldDefinition.model.limit_choices_to };
 
-            if (!cache[url]) {
-              cache[url] = [];
+            // use json filters
+            if (Number.isNaN(parseInt(value as string, 10))) {
+              urlPath = "";
+              filters = { ...JSON.parse(value as string), ...filters };
+
+              // name is mostly not there, use search instead
+              if ("name" in filters) filters.search = filters.name;
+            }
+
+            const url = `${fieldDefinition.model.api_url}/${urlPath}`.replace("//", "/");
+
+            if (!cache[cacheKey]) {
+              cache[cacheKey] = [];
               // eslint-disable-next-line @typescript-eslint/ban-ts-comment
               // @ts-ignore
               inventreeGet(
                 url,
-                { ...fieldDefinition.model.limit_choices_to },
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                { success: (d: any) => cache[url].forEach((handler) => handler(d)) },
+                { ...filters },
+                {
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  success: (item: any) => {
+                    cache[cacheKey].forEach((handler) => handler(item));
+                  },
+                },
               );
             }
-            cache[url].push(handleSuccess);
+            cache[cacheKey].push(handleSuccess);
           }
 
           return `<span id=${cellId} class="placeholder placeholder-glow col-4">${value}</span>`;

--- a/inventree_bulk_plugin/frontend/src/utils/types.ts
+++ b/inventree_bulk_plugin/frontend/src/utils/types.ts
@@ -13,6 +13,7 @@ export interface FieldDefinitionText extends FieldDefinitionBase {
 export interface FieldDefinitionModel extends FieldDefinitionBase {
   field_type: "model";
   model: { model: string; limit_choices_to: Record<string, string>; api_url: string };
+  allow_multiple: boolean;
 }
 
 export interface FieldDefinitionSelect extends FieldDefinitionBase {

--- a/inventree_bulk_plugin/serializers.py
+++ b/inventree_bulk_plugin/serializers.py
@@ -34,6 +34,7 @@ class FieldDefinitionSerializer(serializers.Serializer):
             "description",
             "required",
             "model",
+            "allow_multiple",
             "items_type",
             "fields",
             "default",
@@ -45,6 +46,7 @@ class FieldDefinitionSerializer(serializers.Serializer):
     description = serializers.CharField()
     required = serializers.BooleanField()
     model = serializers.SerializerMethodField()
+    allow_multiple = serializers.BooleanField()
     default = serializers.SerializerMethodField("get_default_method")
     options = serializers.SerializerMethodField("get_options_method")
 

--- a/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
+++ b/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
@@ -577,7 +577,8 @@ class PartBulkCreateObjectTestCase(BulkCreateObjectTestMixin, TestCase):
         ])
 
         # test related parts
-        related_part = Part.objects.create(name="Test to relate this part")
+        related_part = Part.objects.create(name="Test to relate this part",
+                                           description="Test to relate this part description")
         req = self.request.get(f"/abc?parent_id={category.pk}")
         req.user = self.user
         obj = PartBulkCreateObject(req)

--- a/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
+++ b/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
@@ -60,8 +60,8 @@ class BulkCreateObjectsUtilsTestCase(TestCase):
         self.assertEqual(get_model_instance(Company, supplier_company, {"is_supplier": True}), supplier_company)
 
         # test with allow_multiple
-        self.assertEqual(list(get_model_instance(Company, '{"name__endswith": "company"}', {}, allow_multiple=True)), [
-                         supplier_company, customer_company])
+        self.assertCountEqual(list(get_model_instance(Company, '{"name__endswith": "company"}', {}, allow_multiple=True)), [
+            supplier_company, customer_company])
 
         # test with invalid filter
         with self.assertRaisesRegex(ValueError, "Cannot parse json query string at XXX"):
@@ -655,8 +655,8 @@ class PartBulkCreateObjectTestCase(BulkCreateObjectTestMixin, TestCase):
         self.assertEqual(created.description, template_part.description)
         self.assertEqual(created.is_template, False)
         self.assertEqual(created.variant_of, template_part)
-        self.assertEqual(list((p.part.name, p.template.name, p.data) for p in created.get_parameters()), [
-                         ('Test 1_9', 'Test 1', '10'), ('Test 1_9', 'Test 2', '13')])
+        self.assertCountEqual(list((p.part.name, p.template.name, p.data) for p in created.get_parameters()), [
+            ('Test 1_9', 'Test 1', '10'), ('Test 1_9', 'Test 2', '13')])
         self.assertEqual(created.image.name, template_part.image.name)
         self.assertEqual(created.IPN, template_part.IPN)
 

--- a/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
+++ b/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
@@ -17,7 +17,7 @@ from ...bulkcreate_objects import get_model, get_model_instance, cast_model, cas
 # custom request factory, used to patch query_params which were not defined by default
 class CustomRequestFactory(RequestFactory):
     def request(self, **request):
-        data = request.pop("data", None)
+        data = request.pop("data", {})
         r = super().request(**request)
         r.query_params = r.GET or r.POST
         r.data = data

--- a/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
+++ b/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
@@ -55,6 +55,21 @@ class BulkCreateObjectsUtilsTestCase(TestCase):
         with self.assertRaisesRegex(ValueError, "Model 'company.company' where {'pk': " + str(customer_company.pk) + ", 'is_supplier': True} not found at XXX"):
             get_model_instance(Company, customer_company.pk, {"is_supplier": True}, "at XXX")
 
+        # test with an already passed model
+        self.assertEqual(get_model_instance(Company, supplier_company, {"is_supplier": True}), supplier_company)
+
+        # test with allow_multiple
+        self.assertEqual(list(get_model_instance(Company, '{"name__endswith": "company"}', {}, allow_multiple=True)), [
+                         supplier_company, customer_company])
+
+        # test with invalid filter
+        with self.assertRaisesRegex(ValueError, "Cannot parse json query string at XXX"):
+            get_model_instance(Company, '{"a""b"}', {}, "at XXX")
+
+        # test without allow_multiple
+        with self.assertRaisesRegex(ValueError, "Model 'company.company' where {'name__endswith': 'company'} returned multiple models at XXX"):
+            get_model_instance(Company, '{"name__endswith": "company"}', {}, "at XXX")
+
     def test_cast_model(self):
         # shouldn't change anything if field is no model field or uses custom processor
         self.assertEqual(cast_model("10", field=FieldDefinition("A")), "10")

--- a/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
+++ b/inventree_bulk_plugin/tests/integration/test_bulkcreate_objects.py
@@ -17,8 +17,10 @@ from ...bulkcreate_objects import get_model, get_model_instance, cast_model, cas
 # custom request factory, used to patch query_params which were not defined by default
 class CustomRequestFactory(RequestFactory):
     def request(self, **request):
+        data = request.pop("data", None)
         r = super().request(**request)
         r.query_params = r.GET or r.POST
+        r.data = data
         return r
 
 


### PR DESCRIPTION
- [x] variant of => make parts use a tree
- [x] when using variant_of, copy everything by default
- [x] related parts
- [x] model fields allow to get them by json query dict instead of id only, useful for related parts
- [x] tests
- [x] docs

fixes #54 