### PR TITLE
fix dimension words

### DIFF
--- a/inventree_bulk_plugin/BulkGenerator/dimensions.py
+++ b/inventree_bulk_plugin/BulkGenerator/dimensions.py
@@ -8,7 +8,7 @@ from .generators.generator import Generator, GeneratorTypes
 
 def parse_dimension(dimension: str) -> list[tuple[GeneratorTypes, Union[str, tuple[str, str]], dict, str]]:
     res = []
-    for gen_match in re.finditer(r"(?:(?:(\w+)-(\w+))|(\*?\w+))(?:\((.*?)\))?(?:,|$)", dimension):
+    for gen_match in re.finditer(r"(?:(?:(\w+)-(\w+))|(\*?.+?))(?:\((.*?)\))?(?:,|$)", dimension):
         settings = {}
         if gen_match.group(4):
             for setting_match in re.finditer(r"([A-Za-z_]+?)(?:=)([^=]+)(?:,|$)", gen_match.group(4)):

--- a/inventree_bulk_plugin/tests/unit/test_dimensions.py
+++ b/inventree_bulk_plugin/tests/unit/test_dimensions.py
@@ -21,6 +21,14 @@ class DimensionsTestCase(unittest.TestCase):
                 (GeneratorTypes.INFINITY, "abc", {"a": "1", "b": "'(2,3)'", "c": "4"}, "*abc(a=1,b='(2,3)',c=4)"),
                 (GeneratorTypes.RANGE, ("1", "3"), {"a": "1"}, "1-3(a=1)")
             ]),
+            ("hello world,1-3,0.1,0.2,*TEST(a=1),0.3", [
+                (GeneratorTypes.WORD, "hello world", {}, "hello world"),
+                (GeneratorTypes.RANGE, ("1", "3"), {}, "1-3"),
+                (GeneratorTypes.WORD, "0.1", {}, "0.1"),
+                (GeneratorTypes.WORD, "0.2", {}, "0.2"),
+                (GeneratorTypes.INFINITY, "TEST", {"a": "1"}, "*TEST(a=1)"),
+                (GeneratorTypes.WORD, "0.3", {}, "0.3"),
+            ]),
         ]
 
         for test_str, expected_generators in cases:


### PR DESCRIPTION
This PR adds the ability to use non word (`\w+`) matching strings in the dimensions using the word generator type.

fix #70 
