### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
         INVENTREE_PLUGINS_ENABLED: True
         INVENTREE_PLUGIN_TESTING: True
         INVENTREE_PLUGIN_TESTING_SETUP: True
+        INVENTREE_SITE_URL: http://localhost:8000
 
     services:
       db:


### PR DESCRIPTION
This PR fixes the integration tests for InvenTree >= 0.15 where the `INVENTREE_SITE_URL` variable is now required. 