### PR TITLE
Fix ci to work with the latest stable release (>=0.15.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Run tests
         run: |
-          cd /home/inventree${{ matrix.inventree-tag == 'latest' && '/src/backend' || ''  }}
+          cd /home/inventree/src/backend
           HOME=/root coverage run --omit="InvenTree/**" InvenTree/manage.py test inventree_bulk_plugin.tests.integration
           echo $GITHUB_WORKSPACE > coverage_info
 
@@ -153,8 +153,8 @@ jobs:
         with:
           name: integration-coverage
           path: |
-            /home/inventree${{ matrix.inventree-tag == 'latest' && '/src/backend' || ''  }}/.coverage
-            /home/inventree${{ matrix.inventree-tag == 'latest' && '/src/backend' || ''  }}/coverage_info
+            /home/inventree/src/backend/.coverage
+            /home/inventree/src/backend/coverage_info
 
   report:
     name: 📝 Report


### PR DESCRIPTION
Since v0.15 the codebase was restructured, therefore I needed to handle integrations tests a bit different for the *old* stable version (0.14.x), but since the restructure was now released by 0.15.x which now got the stable version, these *hacks* can be removed now and stable and latest should now behave the same.