### PR TITLE
Fix for 0.16.x new way of handling static files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Install this plugin as follows:
 4. Stop your server and run `invoke update` (for docker installs it is `docker-compose inventree-server invoke update`). This ensures that all migrations run and the static files get collected. You can now start your server again and start using the plugin.
 
 > [!IMPORTANT]
-> At least InvenTree v0.12.7 is required to use this plugin.
+> At least InvenTree v0.15.8 is required to use this plugin.
 
 ## 🏃 Usage
 

--- a/README.md
+++ b/README.md
@@ -133,13 +133,13 @@ You can use the global context for some more complex things like generating resi
 
 Install this plugin as follows:
 
-1. Make sure you allow the use of the url integration and app integration (see [Why does this plugin needs the app mixin?](#why-does-this-plugin-needs-the-app-mixin))
+1. Goto the Admin Center > Plugins > Plugin Settings and make sure to enable the "Enable URL Integration" and "Enable App Integration" switches. (see [Why does this plugin needs the app mixin?](#why-does-this-plugin-needs-the-app-mixin))
 
-2. Goto Settings > Plugins > Install Plugin, enter `inventree-bulk-plugin` as package name. Enable the confirm switch and click submit.
+2. Click on "Install Plugin" at the top of the Plugins table on that page and enter `inventree-bulk-plugin` as package name. Enable the "Confirm plugin installation" switch and click "Install".
 
-3. Restart your server and activate the plugin.
+3. Search for the plugin in the table and activate it
 
-4. Stop your server and run `invoke update` (for docker installs it is `docker-compose inventree-server invoke update`). This ensures that all migrations run and the static files get collected. You can now start your server again and start using the plugin.
+4. Stop your server and run `invoke update` (for docker installs it is `docker-compose inventree-server invoke update`). This ensures that all migrations run and the static files get collected. You can now start your server again and start using the plugin by navigating to any stock location or part category (the root level location/category is not available for bulk creation)
 
 > [!IMPORTANT]
 > At least InvenTree v0.15.8 is required to use this plugin.

--- a/inventree_bulk_plugin/InvenTreeBulkPlugin.py
+++ b/inventree_bulk_plugin/InvenTreeBulkPlugin.py
@@ -46,7 +46,8 @@ class InvenTreeBulkPlugin(AppMixin, PanelMixin, UrlsMixin, SettingsMixin, InvenT
     # 0.9.1 - due to "invoke update" doesn't run collectstatic (see inventree/InvenTree#4077)
     # 0.12.6 - Settings do not work in combination with api views (see inventree/InvenTree#5408)
     # 0.12.7 - Fix missing filters for get settings validator (see inventree/InvenTree#5480)
-    MIN_VERSION = "0.12.7"
+    # 0.15.8 - plugin_static template tag was added (see inventree/InvenTree#7764)
+    MIN_VERSION = "0.15.8"
 
     TITLE = "InvenTree Bulk Plugin"
     SLUG = "inventree-bulk-plugin"

--- a/inventree_bulk_plugin/templates/preact-page.html
+++ b/inventree_bulk_plugin/templates/preact-page.html
@@ -1,5 +1,5 @@
-{% load static %}
 {% load inventree_extras %}
+{% load plugin_extras %}
 
 {% define "bulk-create-preact-root__"|add:page|add:id as dom_root %}
 
@@ -18,12 +18,12 @@
   </script>
 {% else %}
   <script type="module">
-    import { render } from "{% static 'inventree-bulk-plugin/dist/'|add:page|add:'.js' %}";
+    import { render } from "{% plugin_static 'inventree-bulk-plugin/dist/'|add:page|add:'.js' %}";
     render({ 
       target: document.getElementById("{{ dom_root }}"),
       objectId: "{{ objectId }}",
       objectType: "{{ objectType }}"
     });
   </script>
-  <link rel="stylesheet" href="{% static 'inventree-bulk-plugin/dist/assets/style.css' %}">
+  <link rel="stylesheet" href="{% plugin_static 'inventree-bulk-plugin/dist/assets/style.css' %}">
 {% endif %}


### PR DESCRIPTION
This PR makes the plugin ready for 0.16.x and bumps the min version to 0.15.8

And thanks to @johanneshk (https://github.com/wolflu05/inventree-bulk-plugin/issues/80#issuecomment-2248262453) I also improved the install documentation now. 